### PR TITLE
#12 download artifact from the most recent run

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Let's suppose you have a workflow with a job in it that at the end uploads an ar
 
 ## Usage
 
-> You need to specify `commit` or `pr` input.
+> If `commit` or `pr` is not specified then the artifact from the most recent run will be downloaded.
 
 ```yaml
 - name: Download artifact

--- a/main.js
+++ b/main.js
@@ -74,6 +74,8 @@ async function main() {
                     return workflow_run.head_sha == commit
                 }
                 else {
+                    // No PR or commit was specified just return the first one. The results appear to be sorted
+                    // so the most recent is first.
                     return true
                 }
             })

--- a/main.js
+++ b/main.js
@@ -69,17 +69,16 @@ async function main() {
         let run
         for await (const response of client.paginate.iterator(options)) {
             
-            if (commit) {
-                const matching_run = response.data.workflow_runs.find((workflow_run) => {
+            run = response.data.workflow_runs.find((workflow_run) => {
+                if (commit) {
                     return workflow_run.head_sha == commit
-                })
-            }
-            else {
-                const matching_run = response.data.workflow_runs[0]
-            }
+                }
+                else {
+                    return true
+                }
+            })
 
-            if (matching_run) {
-                run = matching_run
+            if (run) {
                 break
             }
         }

--- a/main.js
+++ b/main.js
@@ -52,7 +52,12 @@ async function main() {
             commit = pull.data.head.sha
         }
 
-        console.log("==> Commit:", commit)
+        if (commit) {
+            console.log("==> Commit:", commit)
+        }
+        else {
+            console.log("==> No Commit or PR specified - fetching artifact from most recent run")
+        }
 
         // https://github.com/octokit/routes/issues/665
         const options = await client.actions.listWorkflowRunsFixed.endpoint.merge({
@@ -63,9 +68,16 @@ async function main() {
 
         let run
         for await (const response of client.paginate.iterator(options)) {
-            const matching_run = response.data.workflow_runs.find((workflow_run) => {
-                return workflow_run.head_sha == commit
-            })
+            
+            if (commit) {
+                const matching_run = response.data.workflow_runs.find((workflow_run) => {
+                    return workflow_run.head_sha == commit
+                })
+            }
+            else {
+                const matching_run = response.data.workflow_runs[0]
+            }
+
             if (matching_run) {
                 run = matching_run
                 break


### PR DESCRIPTION
Add support for retrieving the artifact from the most recent run if neither PR not commit are specified.