### PR TITLE
Replace "Github" with "GitHub"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Download workflow artifact Github Action
+# Download workflow artifact GitHub Action
 
 An action that downloads and extracts uploaded artifact associated with given workflow and commit.
 

--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,7 @@ branding:
   color: blue
 inputs:
   github_token:
-    description: Github token
+    description: GitHub token
     required: false
     default: ${{github.token}}
   workflow:


### PR DESCRIPTION
It also should be replaced in the repository description.

> ⚙️ A Github Action to download an artifact associated with given workflow and commit