### PR TITLE
Adds branch option

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Let's suppose you have a workflow with a job in it that at the end uploads an ar
 ## Usage
 
 > If `commit` or `pr` is not specified then the artifact from the most recent completed workflow run will be downloaded.
+> If `branch` is specified, it will ignore any value set for `commit` and `pr`.
 
 ```yaml
 - name: Download artifact
@@ -18,6 +19,8 @@ Let's suppose you have a workflow with a job in it that at the end uploads an ar
     pr: ${{github.event.pull_request.number}}
     # Optional, no need to specify if PR is
     commit: ${{github.event.pull_request.head.sha}}
+    # Optional, will use the branch
+    branch: master
     name: artifact_name
     path: extract_here
     # Optional, defaults to current repo

--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,9 @@ inputs:
     description: Where to unpack the artifact
     required: false
     default: "./"
+  branch:
+    description: Branch
+    required: false
 runs:
   using: node12
   main: main.js

--- a/main.js
+++ b/main.js
@@ -11,10 +11,23 @@ async function main() {
         const name = core.getInput("name", { required: true })
         const [owner, repo] = core.getInput("repo", { required: true }).split("/")
         const path = core.getInput("path", { required: true })
-        const pr = core.getInput("pr")
+        const branch = core.getInput("branch")
+        let pr = core.getInput("pr")
         let commit = core.getInput("commit")
 
         const client = github.getOctokit(token)
+
+        if (branch) {
+            console.log("==> Branch:", branch)
+            if (pr) {
+                console.log("==> Branch and PR can not be defined at the same time, ignoring PR:", pr)
+                pr = undefined
+            }
+            if (commit) {
+                console.log("==> Branch and Commit can not be defined at the same time, ignoring Commit:", commit)
+                commit = undefined
+            }
+        }
 
         if (pr) {
             console.log("==> PR:", pr)
@@ -37,6 +50,7 @@ async function main() {
             owner: owner,
             repo: repo,
             id: workflow,
+            branch: branch
         }
         for await (const runs of client.paginate.iterator(endpoint, params)) {
             run = runs.data.find((run) => {


### PR DESCRIPTION
This adds the branch option, it will act similar to `pr`, but instead will specify the branch name.
My usecase is that I always want to fetch an artifact from latest commit of `master`.

I tested locally by passing the params as `INPUT_*`, not sure if there are other ways.


### Setting only `branch`

```bash
$ INPUT_GITHUB_TOKEN=**redacted** INPUT_WORKFLOW=main.yml INPUT_NAME=openapi.json INPUT_REPO=RedHatInsights/policies-ui-backend INPUT_BRANCH=master INPUT_PATH=./  node main.js ==> Branch: master
==> Run: 168904055
==> Artifact: 11093736
==> Downloading: openapi.json.zip (23.61 kB)
  inflating: openapi.json

```

### Setting `branch` and `pr`

```bash
$ INPUT_PR=foobar-pr INPUT_GITHUB_TOKEN=**redacted** INPUT_WORKFLOW=main.yml INPUT_NAME=openapi.json INPUT_REPO=RedHatInsights/policies-ui-backend INPUT_BRANCH=master INPUT_PATH=./  node main.js 
==> Branch: master
==> Branch and PR can not be defined at the same time, ignoring PR: foobar-pr
==> Run: 168904055
==> Artifact: 11093736
==> Downloading: openapi.json.zip (23.61 kB)
  inflating: openapi.json
```

### Setting `branch` and `commit`

```bash
$ INPUT_COMMIT=foobar INPUT_GITHUB_TOKEN=**redacted** INPUT_WORKFLOW=main.yml INPUT_NAME=openapi.json INPUT_REPO=RedHatInsights/policies-ui-backend INPUT_BRANCH=master INPUT_PATH=./  node main.js 
==> Branch: master
==> Branch and Commit can not be defined at the same time, ignoring Commit: foobar
==> Run: 168904055
==> Artifact: 11093736
==> Downloading: openapi.json.zip (23.61 kB)
  inflating: openapi.json
```


### Setting `pr` but not `branch`

```bash
$ INPUT_PR=124 INPUT_GITHUB_TOKEN=**redacted** INPUT_WORKFLOW=main.yml INPUT_NAME=openapi.json INPUT_REPO=RedHatInsights/policies-ui-backend  INPUT_PATH=./  node main.js 
==> PR: 124
==> Commit: 85ccf07bdd9af37cb25710b86bcb9ed1e210d5fc
==> Run: 168417262
==> Artifact: 11053302
==> Downloading: openapi.json.zip (23.61 kB)
  inflating: openapi.json
```

### Setting `commit` but no `branch`
```bash
$ INPUT_COMMIT=85ccf07bdd9af37cb25710b86bcb9ed1e210d5fc INPUT_GITHUB_TOKEN=**redacted** INPUT_WORKFLOW=main.yml INPUT_NAME=openapi.json INPUT_REPO=RedHatInsights/policies-ui-backend  INPUT_PATH=./  node main.js 
==> Commit: 85ccf07bdd9af37cb25710b86bcb9ed1e210d5fc
==> Run: 168417262
==> Artifact: 11053302
==> Downloading: openapi.json.zip (23.61 kB)
  inflating: openapi.json
```