### PR TITLE
Add the support of omitting artifact name

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -27,7 +27,7 @@ inputs:
     required: false
   name:
     description: Artifact name
-    required: true
+    required: false
   path:
     description: Where to unpack the artifact
     required: false


### PR DESCRIPTION
This PR proposes to omit the artifact name and download all. This feature [was added in `actions/download-artifact`](https://github.com/actions/download-artifact#download-all-artifacts) as well. This is useful, for example, when you upload test reports from multiple split jobs, and summarize into one summary report. 

Here is an actual example, https://github.com/apache/spark/pull/29333 and [demo](https://github.com/HyukjinKwon/spark/runs/979902820) (I had to fork this repository to support this feature for now). It'd be nice if this repo has the feature.

I manually tested that it works in the demo above.