### PR TITLE
Add input to specify workflow conclusion

### DIFF
--- a/.github/workflows/download.yml
+++ b/.github/workflows/download.yml
@@ -70,3 +70,18 @@ jobs:
         run: |
           cat artifact1/sha1 | grep $GITHUB_SHA
           cat artifact2/sha2 | grep $GITHUB_SHA
+  download-conclusion:
+    runs-on: ubuntu-latest
+    needs: wait
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Download
+        uses: ./
+        with:
+          workflow: upload.yml
+          name: artifact
+          path: artifact
+          workflow_conclusion: success
+      - name: Test
+        run: cat artifact/sha | grep 378a91650c8f053aefe22c192a49f7ae56101f1c

--- a/.github/workflows/download.yml
+++ b/.github/workflows/download.yml
@@ -84,4 +84,4 @@ jobs:
           path: artifact
           workflow_conclusion: success
       - name: Test
-        run: cat artifact/sha | grep 378a91650c8f053aefe22c192a49f7ae56101f1c
+        run: cat artifact/sha

--- a/.github/workflows/download.yml
+++ b/.github/workflows/download.yml
@@ -84,4 +84,4 @@ jobs:
           path: artifact
           workflow_conclusion: success
       - name: Test
-        run: cat artifact/sha
+        run: cat artifact/sha | grep $GITHUB_SHA

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ Let's suppose you have a workflow with a job in it that at the end uploads an ar
 
 ## Usage
 
-> If `commit` or `pr` or `branch` or `run_id` is not specified then the artifact from the most recent completed workflow run will be downloaded.
+> If `commit` or `pr` or `branch` or `run_id` or `workflow_conclusion` is not specified then the artifact from the most recent completed workflow run will be downloaded.
 
-**Do not specify `pr`, `commit`, `branch` or `run_id` together. Pick just one or none.**
+**Do not specify `pr`, `commit`, `branch`, `run_id` or `workflow_conclusion` together. Pick just one or none.**
 
 ```yaml
 - name: Download artifact
@@ -18,6 +18,11 @@ Let's suppose you have a workflow with a job in it that at the end uploads an ar
     github_token: ${{secrets.GITHUB_TOKEN}}
     # Required, workflow file name or ID
     workflow: workflow_name.yml
+    # Optional, the conclusion of a completed workflow to search for
+    # Can be one of:
+    # "failure", "success", "neutral", "cancelled", "skipped", "timed_out", "action_required"
+    # Ignores conclusion by default (thus using the most recent completed run when no other option is specified, regardless of conclusion)
+    workflow_conclusion: success
     # Optional, will get head commit SHA
     pr: ${{github.event.pull_request.number}}
     # Optional, no need to specify if PR is

--- a/action.yml
+++ b/action.yml
@@ -12,6 +12,9 @@ inputs:
   workflow:
     description: Workflow name
     required: true
+  workflow_conclusion:
+    description: Wanted conclusion to search for in recent runs
+    required: false
   repo:
     description: Repository name with owner (like actions/checkout)
     required: false

--- a/main.js
+++ b/main.js
@@ -23,7 +23,7 @@ async function main() {
         const client = github.getOctokit(token)
 
         if ([runID, branch, pr, commit, workflow_conclusion].filter(elem => elem).length > 1) {
-            throw new Error("don't specify `run_id`, `branch`, `pr`, and `commit` together")
+            throw new Error("don't specify `run_id`, `branch`, `pr`, `commit` and `workflow_conclusion` together")
         }
 
         if(workflow_conclusion && !allowed_workflow_conclusions.includes(workflow_conclusion)) {
@@ -59,12 +59,13 @@ async function main() {
                 const run = runs.data.find(r => {
                     if (commit) {
                         return r.head_sha == commit
-                    }
-                    else {
-                        // No PR or commit was specified just return the first one.
+                    } else if(workflow_conclusion) {
+                        return r.conclusion == workflow_conclusion
+                    } else {
+                        // No PR, commit or conclusion was specified; just return the first one.
                         // The results appear to be sorted from API, so the most recent is first.
                         // Just check if workflow run completed.
-                        return r.status == "completed" && (!workflow_conclusion || r.conclusion == workflow_conclusion)
+                        return r.status == "completed"
                     }
                 })
 


### PR DESCRIPTION
This PR adds the `workflow_conclusion` input which can be used to specify a conclusion to search for in the recent runs.

This is useful when the artifacts are only uploaded when the workflow has a certain conclusion (for example when the run was successful).

In my case I do have dev & live deployments and only want to download artifacts from the latest & succesful dev deployment (in contrast to the latest run which might have failed)