### PR TITLE
Allow workflow status filter to be used with branch, pr, and commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Let's suppose you have a workflow with a job in it that at the end uploads an ar
 
 > If `commit` or `pr` or `branch` or `run_id` or `workflow_conclusion` is not specified then the artifact from the most recent completed workflow run will be downloaded.
 
-**Do not specify `pr`, `commit`, `branch`, `run_id` or `workflow_conclusion` together. Pick just one or none.**
+**Do not specify `pr`, `commit`, `branch`, `run_id` together or `workflow_conclusion` and `run_id` together. Pick just one of each or none.**
 
 ```yaml
 - name: Download artifact
@@ -18,10 +18,12 @@ Let's suppose you have a workflow with a job in it that at the end uploads an ar
     github_token: ${{secrets.GITHUB_TOKEN}}
     # Required, workflow file name or ID
     workflow: workflow_name.yml
-    # Optional, the conclusion of a completed workflow to search for
-    # Can be one of:
+    # Optional, the status or conclusion of a completed workflow to search for
+    # Can be one of a workflow conculsion::
     # "failure", "success", "neutral", "cancelled", "skipped", "timed_out", "action_required"
-    # Ignores conclusion by default (thus using the most recent completed run when no other option is specified, regardless of conclusion)
+    # Or a workflow status:
+    # "completed", "in_progress", "queued"
+    # Default: "completed"
     workflow_conclusion: success
     # Optional, will get head commit SHA
     pr: ${{github.event.pull_request.number}}

--- a/main.js
+++ b/main.js
@@ -16,7 +16,7 @@ async function main() {
         const [owner, repo] = core.getInput("repo", { required: true }).split("/")
         const path = core.getInput("path", { required: true })
         const name = core.getInput("name")
-        const workflow_conclusion = core.getInput("workflow_conclusion")
+        let workflow_conclusion = core.getInput("workflow_conclusion")
         let pr = core.getInput("pr")
         let commit = core.getInput("commit")
         let branch = core.getInput("branch")

--- a/main.js
+++ b/main.js
@@ -64,7 +64,7 @@ async function main() {
                 repo: repo,
                 id: workflow,
                 branch: branch,
-                status: status,
+                status: workflow_conclusion,
             }
             for await (const runs of client.paginate.iterator(endpoint, params)) {
                 const run = runs.data.find(r => {


### PR DESCRIPTION
Closes #39

This allows for `workflow_completion` to be used as an additional filter with `branch`, `pr`, and `commit` to, for example, pull the last successful `master` build for a given workflow.

I ended up merging filtering by workflow status or completion and using this as filter in the API request as Github allows for both as the `status` filter:

https://developer.github.com/v3/actions/workflow-runs/#list-workflow-runs-for-a-repository

This allows us to skip filtering on that on the client-side.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>