### PR TITLE
Added support for run_number

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -31,6 +31,9 @@ inputs:
   run_id:
     description: Workflow run id
     required: false
+  run_number:
+    description: Workflow run number
+    required: false
   name:
     description: Artifact name (download all artifacts in not specified)
     required: false

--- a/main.js
+++ b/main.js
@@ -55,7 +55,6 @@ async function main() {
     }
 
     console.log("==> Repo:", owner + "/" + repo);
-    console.log("==> Updated");
 
     if (pr) {
       console.log("==> PR:", pr);
@@ -91,20 +90,12 @@ async function main() {
             return r.head_sha == commit;
           }
           if (runNumber) {
-            console.log(
-              `RunNumber set ${runNumber} - checking against ${r.run_number}`
-            );
-            if (r.run_number == runNumber) {
-              console.log(`Found correct run with runNumber: ${runNumber}`);
-              return true;
-            }
-            return false;
+            return r.run_number == runNumber;
           }
           return true;
         });
 
         if (run) {
-          console.log(`Run is set`, run);
           runID = run.id;
           break;
         }

--- a/main.js
+++ b/main.js
@@ -86,8 +86,8 @@ async function main() {
           if (commit) {
             return r.head_sha == commit;
           }
-          if (run_number) {
-            return r.run_number === run_number;
+          if (runNumber) {
+            return r.run_number === runNumber;
           }
           return true;
         });

--- a/main.js
+++ b/main.js
@@ -70,6 +70,9 @@ async function main() {
     if (commit) {
       console.log("==> Commit:", commit);
     }
+    if (runNumber) {
+      console.log("==> RunNumber:", runNumber);
+    }
 
     if (!runID) {
       const endpoint =
@@ -86,6 +89,7 @@ async function main() {
           if (commit) {
             return r.head_sha == commit;
           }
+          console.log(r);
           if (runNumber) {
             return r.run_number === runNumber;
           }

--- a/main.js
+++ b/main.js
@@ -55,6 +55,7 @@ async function main() {
     }
 
     console.log("==> Repo:", owner + "/" + repo);
+    console.log("==> Updated");
 
     if (pr) {
       console.log("==> PR:", pr);

--- a/main.js
+++ b/main.js
@@ -1,138 +1,155 @@
-const core = require('@actions/core')
-const github = require('@actions/github')
-const AdmZip = require('adm-zip')
-const filesize = require('filesize')
-const pathname = require('path')
-const fs = require("fs")
+const core = require("@actions/core");
+const github = require("@actions/github");
+const AdmZip = require("adm-zip");
+const filesize = require("filesize");
+const pathname = require("path");
+const fs = require("fs");
 
 // https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#list-workflow-runs
 // allows for both status or conclusion to be used as status filter
-const allowed_workflow_conclusions = ["failure", "success", "neutral", "cancelled", "skipped", "timed_out", "action_required", "queued", "in_progress", "completed"];
+const allowed_workflow_conclusions = [
+  "failure",
+  "success",
+  "neutral",
+  "cancelled",
+  "skipped",
+  "timed_out",
+  "action_required",
+  "queued",
+  "in_progress",
+  "completed",
+];
 
 async function main() {
-    try {
-        const token = core.getInput("github_token", { required: true })
-        const workflow = core.getInput("workflow", { required: true })
-        const [owner, repo] = core.getInput("repo", { required: true }).split("/")
-        const path = core.getInput("path", { required: true })
-        const name = core.getInput("name")
-        let workflow_conclusion = core.getInput("workflow_conclusion")
-        let pr = core.getInput("pr")
-        let commit = core.getInput("commit")
-        let branch = core.getInput("branch")
-        let runID = core.getInput("run_id")
+  try {
+    const token = core.getInput("github_token", { required: true });
+    const workflow = core.getInput("workflow", { required: true });
+    const [owner, repo] = core.getInput("repo", { required: true }).split("/");
+    const path = core.getInput("path", { required: true });
+    const name = core.getInput("name");
+    let workflow_conclusion = core.getInput("workflow_conclusion");
+    let pr = core.getInput("pr");
+    let commit = core.getInput("commit");
+    let branch = core.getInput("branch");
+    let runID = core.getInput("run_id");
+    let runNumber = core.getInput("run_number");
 
-        const client = github.getOctokit(token)
+    const client = github.getOctokit(token);
 
-        if ([runID, branch, pr, commit].filter(elem => elem).length > 1) {
-            throw new Error("don't specify `run_id`, `branch`, `pr`, `commit` together")
-        }
-
-        if ([runID, workflow_conclusion].filter(elem => elem).length > 1) {
-            throw new Error("don't specify `run_id`, `workflow_conclusion` together")
-        }
-
-        if (!workflow_conclusion) {
-            workflow_conclusion = "completed"
-        }
-
-        if(!allowed_workflow_conclusions.includes(workflow_conclusion)) {
-            throw new Error(`Unknown workflow conclusion '${workflow_conclusion}'`)
-        }
-
-        console.log("==> Repo:", owner + "/" + repo)
-
-        if (pr) {
-            console.log("==> PR:", pr)
-
-            const pull = await client.pulls.get({
-                owner: owner,
-                repo: repo,
-                pull_number: pr,
-            })
-            commit = pull.data.head.sha
-        }
-
-        if (commit) {
-            console.log("==> Commit:", commit)
-        }
-
-        if (!runID) {
-            const endpoint = "GET /repos/:owner/:repo/actions/workflows/:id/runs?status=:status"
-            const params = {
-                owner: owner,
-                repo: repo,
-                id: workflow,
-                branch: branch,
-                status: workflow_conclusion,
-            }
-            for await (const runs of client.paginate.iterator(endpoint, params)) {
-                const run = runs.data.find(r => {
-                    if (commit) {
-                        return r.head_sha == commit
-                    }
-                    return true
-                })
-
-                if (run) {
-                    runID = run.id
-                    break
-                }
-            }
-        }
-
-        console.log("==> RunID:", runID)
-
-        let artifacts = await client.actions.listWorkflowRunArtifacts({
-            owner: owner,
-            repo: repo,
-            run_id: runID,
-        })
-
-        // One artifact or all if `name` input is not specified.
-        if (name) {
-            artifacts = artifacts.data.artifacts.filter((artifact) => {
-                return artifact.name == name
-            })
-        } else {
-            artifacts = artifacts.data.artifacts
-        }
-
-        if (artifacts.length == 0)
-            throw new Error("no artifacts found")
-
-        for (const artifact of artifacts) {
-            console.log("==> Artifact:", artifact.id)
-
-            const size = filesize(artifact.size_in_bytes, { base: 10 })
-
-            console.log("==> Downloading:", artifact.name + ".zip", `(${size})`)
-
-            const zip = await client.actions.downloadArtifact({
-                owner: owner,
-                repo: repo,
-                artifact_id: artifact.id,
-                archive_format: "zip",
-            })
-
-            const dir = name ? path : pathname.join(path, artifact.name)
-
-            fs.mkdirSync(dir, { recursive: true })
-
-            const adm = new AdmZip(Buffer.from(zip.data))
-
-            adm.getEntries().forEach((entry) => {
-                const action = entry.isDirectory ? "creating" : "inflating"
-                const filepath = pathname.join(dir, entry.entryName)
-
-                console.log(`  ${action}: ${filepath}`)
-            })
-
-            adm.extractAllTo(dir, true)
-        }
-    } catch (error) {
-        core.setFailed(error.message)
+    if ([runID, branch, pr, commit].filter((elem) => elem).length > 1) {
+      throw new Error(
+        "don't specify `run_id`, `branch`, `pr`, `commit` together"
+      );
     }
+
+    if ([runID, workflow_conclusion].filter((elem) => elem).length > 1) {
+      throw new Error("don't specify `run_id`, `workflow_conclusion` together");
+    }
+
+    if (!workflow_conclusion) {
+      workflow_conclusion = "completed";
+    }
+
+    if (!allowed_workflow_conclusions.includes(workflow_conclusion)) {
+      throw new Error(`Unknown workflow conclusion '${workflow_conclusion}'`);
+    }
+
+    console.log("==> Repo:", owner + "/" + repo);
+
+    if (pr) {
+      console.log("==> PR:", pr);
+
+      const pull = await client.pulls.get({
+        owner: owner,
+        repo: repo,
+        pull_number: pr,
+      });
+      commit = pull.data.head.sha;
+    }
+
+    if (commit) {
+      console.log("==> Commit:", commit);
+    }
+
+    if (!runID) {
+      const endpoint =
+        "GET /repos/:owner/:repo/actions/workflows/:id/runs?status=:status";
+      const params = {
+        owner: owner,
+        repo: repo,
+        id: workflow,
+        branch: branch,
+        status: workflow_conclusion,
+      };
+      for await (const runs of client.paginate.iterator(endpoint, params)) {
+        const run = runs.data.find((r) => {
+          if (commit) {
+            return r.head_sha == commit;
+          }
+          if (run_number) {
+            return r.run_number === run_number;
+          }
+          return true;
+        });
+
+        if (run) {
+          runID = run.id;
+          break;
+        }
+      }
+    }
+
+    console.log("==> RunID:", runID);
+
+    let artifacts = await client.actions.listWorkflowRunArtifacts({
+      owner: owner,
+      repo: repo,
+      run_id: runID,
+    });
+
+    // One artifact or all if `name` input is not specified.
+    if (name) {
+      artifacts = artifacts.data.artifacts.filter((artifact) => {
+        return artifact.name == name;
+      });
+    } else {
+      artifacts = artifacts.data.artifacts;
+    }
+
+    if (artifacts.length == 0) throw new Error("no artifacts found");
+
+    for (const artifact of artifacts) {
+      console.log("==> Artifact:", artifact.id);
+
+      const size = filesize(artifact.size_in_bytes, { base: 10 });
+
+      console.log("==> Downloading:", artifact.name + ".zip", `(${size})`);
+
+      const zip = await client.actions.downloadArtifact({
+        owner: owner,
+        repo: repo,
+        artifact_id: artifact.id,
+        archive_format: "zip",
+      });
+
+      const dir = name ? path : pathname.join(path, artifact.name);
+
+      fs.mkdirSync(dir, { recursive: true });
+
+      const adm = new AdmZip(Buffer.from(zip.data));
+
+      adm.getEntries().forEach((entry) => {
+        const action = entry.isDirectory ? "creating" : "inflating";
+        const filepath = pathname.join(dir, entry.entryName);
+
+        console.log(`  ${action}: ${filepath}`);
+      });
+
+      adm.extractAllTo(dir, true);
+    }
+  } catch (error) {
+    core.setFailed(error.message);
+  }
 }
 
-main()
+main();

--- a/main.js
+++ b/main.js
@@ -90,14 +90,21 @@ async function main() {
           if (commit) {
             return r.head_sha == commit;
           }
-          console.log(r);
           if (runNumber) {
-            return r.run_number === runNumber;
+            console.log(
+              `RunNumber set ${runNumber} - checking against ${r.run_number}`
+            );
+            if (r.run_number == runNumber) {
+              console.log(`Found correct run with runNumber: ${runNumber}`);
+              return true;
+            }
+            return false;
           }
           return true;
         });
 
         if (run) {
+          console.log(`Run is set`, run);
           runID = run.id;
           break;
         }


### PR DESCRIPTION
Resolved bug where if you did not specify runID, but a name, it will only retrieve the latest workflow run.
Therefore added property run_number, which is used to filter out the correct workflow run. 

This adds the possibility to specify an earlier workflow run than the very latest.

In addition, ran prettier over the project file.  Most changes are from line 77:100