### PR TITLE
Add Pagination Support for Runs with >30 Artifacts

### DIFF
--- a/main.js
+++ b/main.js
@@ -85,19 +85,17 @@ async function main() {
 
         console.log("==> RunID:", runID)
 
-        let artifacts = await client.actions.listWorkflowRunArtifacts({
+        let artifacts = await client.paginate(client.actions.listWorkflowRunArtifacts, {
             owner: owner,
             repo: repo,
             run_id: runID,
-        })
+        });
 
         // One artifact or all if `name` input is not specified.
         if (name) {
-            artifacts = artifacts.data.artifacts.filter((artifact) => {
+            artifacts = artifacts.filter((artifact) => {
                 return artifact.name == name
             })
-        } else {
-            artifacts = artifacts.data.artifacts
         }
 
         if (artifacts.length == 0)


### PR DESCRIPTION
Currently, runs with over 30 artifacts only download the first 30 published. This PR adds support to page through all artifacts and download them accordingly.