### PR TITLE
Scan for matching  `pr == run.pull_request.*.number`

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Let's suppose you have a workflow with a job in it that at the end uploads an ar
     # Or a workflow status:
     #   "completed", "in_progress", "queued"
     workflow_conclusion: success
-    # Optional, will get search runs for matching pull_request.*.number
+    # Optional, will scan runs for matching pull_request.*.number
     pr: ${{github.event.pull_request.number}}
     # Optional, no need to specify if PR is
     commit: ${{github.event.pull_request.head.sha}}

--- a/main.js
+++ b/main.js
@@ -31,13 +31,6 @@ async function main() {
 
         if (pr) {
             console.log("==> PR:", pr)
-
-            const pull = await client.pulls.get({
-                owner: owner,
-                repo: repo,
-                pull_number: pr,
-            })
-            commit = pull.data.head.sha
         }
 
         if (commit) {
@@ -68,6 +61,9 @@ async function main() {
             )) {
                 for (const run of runs.data) {
                     if (commit && run.head_sha != commit) {
+                        continue
+                    }
+                    if (pr && !run.pull_requests.some(x => x.number == pr)) {
                         continue
                     }
                     if (runNumber && run.run_number != runNumber) {


### PR DESCRIPTION
I propose that the PR parameter should search for matching `pull_request`s when scanning through matching workflow runs. 

I encountered a situation where a prior workflow run on a PR had yielded a suitable artifact, but then that same workflow configuration was skipped on subsequent successive `synchronize`s due to no changes in the application's source files, only files related to infrastructure as code deployment changed. The skipped nature of the workflow meant that the head sha of the PR no longer matched the commit sha that yielded the artifact, so this task began failing.

This fixed that particular use case. It does assume that the workflow run scan order starts with the most recent.

_Good work on this task, it is extremely useful for orchestrating workflows! I'm guessing the check suite fails due to cross-fork repo. The [download test passed in my actions](https://github.com/t-l-k/action-download-artifact/actions/runs/1246243434)._