### PR TITLE
Enable multiple artifact download & artifact name via regex

### DIFF
--- a/.github/workflows/download.yml
+++ b/.github/workflows/download.yml
@@ -58,7 +58,7 @@ jobs:
           pr: ${{github.event.pull_request.number}}
       - name: Test
         run: cat artifact/sha | grep $GITHUB_SHA
-  download-multiple:
+  download-all:
     runs-on: ubuntu-latest
     needs: wait
     steps:
@@ -72,6 +72,39 @@ jobs:
         run: |
           cat artifact1/sha1 | grep $GITHUB_SHA
           cat artifact2/sha2 | grep $GITHUB_SHA
+  download-multiple:
+    runs-on: ubuntu-latest
+    needs: wait
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Download
+        uses: ./
+        with:
+          workflow: upload.yml
+          name: 'artifact1,
+                 artifact2'
+      - name: Test
+        run: |
+          ls -alth
+          cat artifact1/sha1 | grep $GITHUB_SHA
+          cat artifact2/sha2 | grep $GITHUB_SHA
+  download-wildcard:
+    runs-on: ubuntu-latest
+    needs: wait
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Download
+        uses: ./
+        with:
+          workflow: upload.yml
+          name: '*.txt'
+      - name: Test
+        run: |
+          ls -alth
+          cat artifact1.txt/sha1 | grep $GITHUB_SHA
+          cat artifact2.txt/sha2 | grep $GITHUB_SHA
   download-conclusion:
     runs-on: ubuntu-latest
     needs: wait

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -37,3 +37,21 @@ jobs:
         with:
           name: artifact2
           path: artifact2
+  upload-multiple-wildcard-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dump
+        run: |
+          mkdir artifact1 artifact2
+          echo $GITHUB_SHA > artifact1/sha1
+          echo $GITHUB_SHA > artifact2/sha2
+      - name: Upload first
+        uses: actions/upload-artifact@v2
+        with:
+          name: artifact1.txt
+          path: artifact1
+      - name: Upload second
+        uses: actions/upload-artifact@v2
+        with:
+          name: artifact2.txt
+          path: artifact2

--- a/README.md
+++ b/README.md
@@ -38,9 +38,8 @@ Let's suppose you have a workflow with a job in it that at the end uploads an ar
     run_id: 1122334455
     # Optional, run number from the workflow
     run_number: 34
-    # Optional, uploaded artifact name,
-    # will download all artifacts if not specified
-    # and extract them in respective subdirectories
+    # Optional, uploaded artifact name or comma seperated list of artifact names
+    # If not specified, will download all artifacts and extract them in respective subdirectories
     # https://github.com/actions/download-artifact#download-all-artifacts
     name: artifact_name
     # Optional, directory where to extract artifact. Defaults to the artifact name (see `name` input)

--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ Let's suppose you have a workflow with a job in it that at the end uploads an ar
     # Optional, run number from the workflow
     run_number: 34
     # Optional, uploaded artifact name or comma seperated list of artifact names
-    # If not specified, will download all artifacts and extract them in respective subdirectories
+    # If not specified, will download all artifacts
+    # If more than one artifact is downloaded, they will be extracted into their respective subdirectories
     # https://github.com/actions/download-artifact#download-all-artifacts
     name: artifact_name
     # Optional, directory where to extract artifact. Defaults to the artifact name (see `name` input)

--- a/main.js
+++ b/main.js
@@ -109,8 +109,9 @@ async function main() {
 
         // One artifact or all if `name` input is not specified.
         if (name) {
+            const names = name.split(",").map(name => name.trim())
             artifacts = artifacts.filter((artifact) => {
-                return artifact.name == name
+                return names.includes(artifact.name)
             })
         }
 

--- a/main.js
+++ b/main.js
@@ -112,14 +112,9 @@ async function main() {
             const matchesWithRegex = (stringToTest, regexRule) => {
                 const escapeSpecialChars = (string) => string.replace(/([.*+?^=!:${}()|\[\]\/\\])/g, "\\$1");
                 const builtRegexRule = "^" + regexRule.split("*").map(escapeSpecialChars).join(".*") + "$"
-                const match = new RegExp(builtRegexRule).test(stringToTest)
-
-                console.log(`[DEBUG] name: ${regexRule}, artifact: ${stringToTest}, regexRule: ${builtRegexRule}, match: ${match}`)
-                return match
+                return new RegExp(builtRegexRule).test(stringToTest)
             }
             const names = name.split(",").map(name => name.trim())
-            console.log(`[DEBUG] names: ${JSON.stringify(names, null, 4)}`)
-            console.log(`[DEBUG] artifacts: ${JSON.stringify(artifacts.map(artifact => artifact.name), null, 4)}`)
 
             artifacts = artifacts.filter(artifact => {
                 return names.map(name => matchesWithRegex(artifact.name, name)).reduce((prevValue, currValue) => prevValue || currValue)

--- a/main.js
+++ b/main.js
@@ -107,11 +107,22 @@ async function main() {
             run_id: runID,
         })
 
-        // One artifact or all if `name` input is not specified.
+        // One artifact, a list of artifacts, or all if `name` input is not specified.
         if (name) {
+            const matchesWithRegex = (stringToTest, regexRule) => {
+                const escapeSpecialChars = (string) => string.replace(/([.*+?^=!:${}()|\[\]\/\\])/g, "\\$1");
+                const builtRegexRule = "^" + regexRule.split("*").map(escapeSpecialChars).join(".*") + "$"
+                const match = new RegExp(builtRegexRule).test(stringToTest)
+
+                console.log(`[DEBUG] name: ${regexRule}, artifact: ${stringToTest}, regexRule: ${builtRegexRule}, match: ${match}`)
+                return match
+            }
             const names = name.split(",").map(name => name.trim())
-            artifacts = artifacts.filter((artifact) => {
-                return names.includes(artifact.name)
+            console.log(`[DEBUG] names: ${JSON.stringify(names, null, 4)}`)
+            console.log(`[DEBUG] artifacts: ${JSON.stringify(artifacts.map(artifact => artifact.name), null, 4)}`)
+
+            artifacts = artifacts.filter(artifact => {
+                return names.map(name => matchesWithRegex(artifact.name, name)).reduce((prevValue, currValue) => prevValue || currValue)
             })
         }
 
@@ -132,7 +143,7 @@ async function main() {
                 archive_format: "zip",
             })
 
-            const dir = name ? path : pathname.join(path, artifact.name)
+            const dir = artifacts.length == 1 ? path : pathname.join(path, artifact.name)
 
             fs.mkdirSync(dir, { recursive: true })
 


### PR DESCRIPTION
## Summary

First off, I have found this Action very useful! Thanks for creating it!

For workflows that need multiple artifacts from another workflow, but not all, I'd like the ability to specify specifically which ones to get to avoid downloading more than I need. This change enables that.