### PR TITLE
Fix default path bug

### DIFF
--- a/.github/workflows/download.yml
+++ b/.github/workflows/download.yml
@@ -84,6 +84,6 @@ jobs:
           workflow: upload.yml
           name: artifact
           path: artifact
-          workflow_conclusion: success
+          workflow_conclusion: ''
       - name: Test
         run: cat artifact/sha | grep $GITHUB_SHA

--- a/.github/workflows/download.yml
+++ b/.github/workflows/download.yml
@@ -24,7 +24,7 @@ jobs:
           workflow: upload.yml
           name: artifact
       - name: Test default behavior
-        run: cat artifact/sha | grep $GITHUB_SHA
+        run: cat artifacts/sha | grep $GITHUB_SHA
   download-latest:
     runs-on: ubuntu-latest
     needs: wait

--- a/README.md
+++ b/README.md
@@ -46,4 +46,8 @@ Let's suppose you have a workflow with a job in it that at the end uploads an ar
     path: extract_here
     # Optional, defaults to current repo
     repo: ${{github.repository}}
+    # Optional, check the workflow run whether it has an artifact
+    # then will get the last available artifact from previous workflow
+    # default false, just try to download from the last one
+    check_artifacts:  false
 ```

--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ Let's suppose you have a workflow with a job in it that at the end uploads an ar
   uses: dawidd6/action-download-artifact@v2
   with:
     # Optional, GitHub token, a Personal Access Token with `public_repo` scope if needed
-    github_token: ${{secrets.GITHUB_TOKEN}}, required if artifact is from a different repo
+    # Required, if artifact is from a different repo
+    github_token: ${{secrets.GITHUB_TOKEN}}
     # Required, workflow file name or ID
     workflow: workflow_name.yml
     # Optional, the status or conclusion of a completed workflow to search for

--- a/README.md
+++ b/README.md
@@ -51,4 +51,7 @@ Let's suppose you have a workflow with a job in it that at the end uploads an ar
     # then will get the last available artifact from previous workflow
     # default false, just try to download from the last one
     check_artifacts:  false
+    # Optional, search for the last workflow run whose stored an artifact named as in `name` input
+    # default false
+    search_artifacts: false
 ```

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Let's suppose you have a workflow with a job in it that at the end uploads an ar
   with:
     # Optional, GitHub token, a Personal Access Token with `public_repo` scope if needed
     # Required, if artifact is from a different repo
+    # Required, if repo is private a Personal Access Token with `repo` scope is needed
     github_token: ${{secrets.GITHUB_TOKEN}}
     # Required, workflow file name or ID
     workflow: workflow_name.yml

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Let's suppose you have a workflow with a job in it that at the end uploads an ar
     workflow: workflow_name.yml
     # Optional, the status or conclusion of a completed workflow to search for
     # Can be one of a workflow conclusion:
-    #.  "failure", "success", "neutral", "cancelled", "skipped", "timed_out", "action_required"
+    #   "failure", "success", "neutral", "cancelled", "skipped", "timed_out", "action_required"
     # Or a workflow status:
     #   "completed", "in_progress", "queued"
     workflow_conclusion: success

--- a/README.md
+++ b/README.md
@@ -20,11 +20,10 @@ Let's suppose you have a workflow with a job in it that at the end uploads an ar
     # Required, workflow file name or ID
     workflow: workflow_name.yml
     # Optional, the status or conclusion of a completed workflow to search for
-    # Can be one of a workflow conclusion::
-    # "failure", "success", "neutral", "cancelled", "skipped", "timed_out", "action_required"
+    # Can be one of a workflow conclusion:
+    #.  "failure", "success", "neutral", "cancelled", "skipped", "timed_out", "action_required"
     # Or a workflow status:
-    # "completed", "in_progress", "queued"
-    # Default: "completed,success"
+    #   "completed", "in_progress", "queued"
     workflow_conclusion: success
     # Optional, will get head commit SHA
     pr: ${{github.event.pull_request.number}}

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Let's suppose you have a workflow with a job in it that at the end uploads an ar
     # and extract them in respective subdirectories
     # https://github.com/actions/download-artifact#download-all-artifacts
     name: artifact_name
-    # Optional, directory where to extract artifact. Defaults to the artifact name (see `name` input)
+    # Optional, directory where to extract artifact. Defaults to the './artifacts'
     path: extract_here
     # Optional, defaults to current repo
     repo: ${{github.repository}}

--- a/action.yml
+++ b/action.yml
@@ -51,6 +51,9 @@ inputs:
   check_artifacts:
     description: Check workflow run whether it has an artifact
     required: false
+  search_artifacts:
+    description: Search workflow runs for artifact with specified name
+    required: false
 runs:
   using: node12
   main: main.js

--- a/action.yml
+++ b/action.yml
@@ -48,6 +48,9 @@ inputs:
     description: Where to unpack the artifact
     required: false
     default: "./"
+  check_artifacts:
+    description: Check workflow run whether it has an artifact
+    required: false
 runs:
   using: node12
   main: main.js

--- a/action.yml
+++ b/action.yml
@@ -14,11 +14,11 @@ inputs:
     required: true
   workflow_conclusion:
     description: |
-      Wanted status or conclusion or both to search for in recent runs
+      Wanted status or conclusion to search for in recent runs
 
       https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#list-workflow-runs
     required: false
-    default: completed,success
+    default: success
   repo:
     description: Repository name with owner (like actions/checkout)
     required: false

--- a/action.yml
+++ b/action.yml
@@ -54,6 +54,9 @@ inputs:
   search_artifacts:
     description: Search workflow runs for artifact with specified name
     required: false
+outputs:
+  error_message:
+    description: The error message, if an error occurs
 runs:
   using: node12
   main: main.js

--- a/action.yml
+++ b/action.yml
@@ -47,7 +47,7 @@ inputs:
   path:
     description: Where to unpack the artifact
     required: false
-    default: "./"
+    default: "./artifacts"
   check_artifacts:
     description: Check workflow run whether it has an artifact
     required: false

--- a/main.js
+++ b/main.js
@@ -156,6 +156,7 @@ async function main() {
             adm.extractAllTo(dir, true)
         }
     } catch (error) {
+        core.setOutput("error_message", error.message)
         core.setFailed(error.message)
     }
 }

--- a/main.js
+++ b/main.js
@@ -19,6 +19,7 @@ async function main() {
         let event = core.getInput("event")
         let runID = core.getInput("run_id")
         let runNumber = core.getInput("run_number")
+        let checkArtifacts = core.getInput("check_artifacts")
 
         const client = github.getOctokit(token)
 
@@ -74,6 +75,16 @@ async function main() {
                     }
                     if (workflowConclusion && (workflowConclusion != run.conclusion && workflowConclusion != run.status)) {
                         continue
+                    }
+                    if (checkArtifacts) {
+                        let artifacts = await client.actions.listWorkflowRunArtifacts({
+                            owner: owner,
+                            repo: repo,
+                            run_id: run.id,
+                        })
+                        if (artifacts.data.artifacts.length == 0) {
+                            continue
+                        }
                     }
                     runID = run.id
                     break

--- a/main.js
+++ b/main.js
@@ -140,7 +140,7 @@ async function main() {
                 archive_format: "zip",
             })
 
-            const dir = name ? path : pathname.join(path, artifact.name)
+            const dir = name ? pathname.join(path, name) : pathname.join(path, artifact.name)
 
             fs.mkdirSync(dir, { recursive: true })
 

--- a/main.js
+++ b/main.js
@@ -83,7 +83,11 @@ async function main() {
             }
         }
 
-        console.log("==> RunID:", runID)
+        if (runID) {
+            console.log("==> RunID:", runID)
+        } else {
+            throw new Error("no matching workflow run found")
+        }
 
         let artifacts = await client.paginate(client.actions.listWorkflowRunArtifacts, {
             owner: owner,

--- a/main.js
+++ b/main.js
@@ -20,6 +20,7 @@ async function main() {
         let runID = core.getInput("run_id")
         let runNumber = core.getInput("run_number")
         let checkArtifacts = core.getInput("check_artifacts")
+        let searchArtifacts = core.getInput("search_artifacts")
 
         const client = github.getOctokit(token)
 
@@ -76,7 +77,7 @@ async function main() {
                     if (workflowConclusion && (workflowConclusion != run.conclusion && workflowConclusion != run.status)) {
                         continue
                     }
-                    if (checkArtifacts) {
+                    if (checkArtifacts || searchArtifacts) {
                         let artifacts = await client.actions.listWorkflowRunArtifacts({
                             owner: owner,
                             repo: repo,
@@ -84,6 +85,14 @@ async function main() {
                         })
                         if (artifacts.data.artifacts.length == 0) {
                             continue
+                        }
+                        if (searchArtifacts) {
+                            const artifact = artifacts.data.artifacts.find((artifact) => {
+                                return artifact.name == name
+                            })
+                            if (!artifact) {
+                                continue
+                            }
                         }
                     }
                     runID = run.id
@@ -152,3 +161,4 @@ async function main() {
 }
 
 main()
+

--- a/main.js
+++ b/main.js
@@ -63,21 +63,22 @@ async function main() {
                 workflow_id: workflow,
                 branch: branch,
                 event: event,
-                status: workflowConclusion,
             }
             )) {
-                const run = runs.data.find(r => {
-                    if (commit) {
-                        return r.head_sha == commit
+                for (const run of runs.data) {
+                    if (commit && run.head_sha != commit) {
+                        continue
                     }
-                    if (runNumber) {
-                        return r.run_number == runNumber
+                    if (runNumber && run.run_number != runNumber) {
+                        continue
                     }
-                    return true
-                })
-
-                if (run) {
+                    if (workflowConclusion && (workflowConclusion != run.conclusion && workflowConclusion != run.status)) {
+                        continue
+                    }
                     runID = run.id
+                    break
+                }
+                if (runID) {
                     break
                 }
             }

--- a/main.js
+++ b/main.js
@@ -140,12 +140,7 @@ async function main() {
                 archive_format: "zip",
             })
 
-            let dir = name
-            if (!name) {
-                dir = pathname.join(path, artifact.name)
-            } else if (path !== './') {
-                dir = path
-            } 
+            const dir = name ? path : pathname.join(path, artifact.name)
 
             fs.mkdirSync(dir, { recursive: true })
 

--- a/main.js
+++ b/main.js
@@ -89,7 +89,7 @@ async function main() {
             owner: owner,
             repo: repo,
             run_id: runID,
-        });
+        })
 
         // One artifact or all if `name` input is not specified.
         if (name) {


### PR DESCRIPTION
The documentation of `path` states that the default path is the artifact's name, but instead, the action puts the artifact's content in the current working directory `./`.
Moreover, using `./` as the default path poses security implications (exact details sent to action maintainer via email).
This PR changes the default path to `./artifacts` and fixes the documentation accordingly.

Please note this is a breaking change. Users of this action who didn't specify a `path` will need to do one of the following options:
- change the code that handles the downloaded files to look for them inside `./artifacts/` (recommended)
- use the action with `path: ./` (insecure, not recommended)
- use the old action `uses: dawidd6/action-download-artifact@v2.17.0` (insecure, not recommended)