### PR TITLE
initialize branch with pr ref in addition to commit

### DIFF
--- a/main.js
+++ b/main.js
@@ -39,6 +39,7 @@ async function main() {
                 pull_number: pr,
             })
             commit = pull.data.head.sha
+            branch = pull.data.head.ref
         }
 
         if (commit) {


### PR DESCRIPTION
Unlike commit, branch is a parameter that is able to be filtered in the listWorkflowRuns request, so should reduce the number of potential matches that need to be iterated in the action.