### PR TITLE
README: fix commentary order

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ Let's suppose you have a workflow with a job in it that at the end uploads an ar
     # Or a workflow status:
     #   "completed", "in_progress", "queued"
     workflow_conclusion: success
-    # Optional, will get head commit SHA
-    pr: ${{github.event.pull_request.number}}
     # Optional, no need to specify if PR is
+    pr: ${{github.event.pull_request.number}}
+    # Optional, will get head commit SHA
     commit: ${{github.event.pull_request.head.sha}}
     # Optional, will use the branch
     branch: master


### PR DESCRIPTION
It seems that 2 comments need to be switched each other.