### PR TITLE
fix: do not set empty "branch" and "event" as filters

### DIFF
--- a/main.js
+++ b/main.js
@@ -39,7 +39,7 @@ async function main() {
                 pull_number: pr,
             })
             commit = pull.data.head.sha
-            branch = pull.data.head.ref
+            //branch = pull.data.head.ref
         }
 
         if (commit) {

--- a/main.js
+++ b/main.js
@@ -64,8 +64,8 @@ async function main() {
                 owner: owner,
                 repo: repo,
                 workflow_id: workflow,
-                branch: branch,
-                event: event,
+                ...(branch ? { branch } : {}),
+                ...(event ? { event } : {}),
             }
             )) {
                 for (const run of runs.data) {


### PR DESCRIPTION
With empty filters (both "branch" and "event" set to empty strings) there are fewer results (please see the `watch` section on the left) than without specifying those filters. Related to https://github.com/dawidd6/action-download-artifact/issues/147.

<img width="1511" alt="empty-strings" src="https://user-images.githubusercontent.com/26244440/163156873-8fd75ea6-3700-4d51-a9c0-bad5707fb76e.png">
<img width="1494" alt="commented" src="https://user-images.githubusercontent.com/26244440/163156884-49d77092-e701-4223-916a-5d4d68a5d472.png">
