### PR TITLE
write zip file in path

### DIFF
--- a/.github/workflows/download.yml
+++ b/.github/workflows/download.yml
@@ -103,9 +103,11 @@ jobs:
           skip_unpack: true
       - name: Test
         run: |
-          test -f artifact.zip
-          ! test -d artifact
-          unzip -l artifact.zip
+          test -d artifact
+          test -f artifact/artifact.zip
+          ! test -d artifact/artifact
+          ! test -f artifact.zip
+          unzip -l artifact/artifact.zip
   download-dry-run-exists:
     runs-on: ubuntu-latest
     needs: wait

--- a/main.js
+++ b/main.js
@@ -191,7 +191,8 @@ async function main() {
             })
 
             if (skipUnpack) {
-                fs.writeFileSync(`${artifact.name}.zip`, Buffer.from(zip.data), 'binary')
+                fs.mkdirSync(path, { recursive: true })
+                fs.writeFileSync(`${pathname.join(path, artifact.name)}.zip`, Buffer.from(zip.data), 'binary')
                 continue
             }
 


### PR DESCRIPTION
Now if we check unpacking, the zip file will be written according to the path specified, and not in the current folder
Fixes #168