### PR TITLE
Make 'workflow' input optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ Let's suppose you have a workflow with a job in it that at the end uploads an ar
     # Required, if artifact is from a different repo
     # Required, if repo is private a Personal Access Token with `repo` scope is needed
     github_token: ${{secrets.GITHUB_TOKEN}}
-    # Required, workflow file name or ID
+    # Optional, workflow file name or ID
+    # If not specified, will be inferred from run_id (if run_id is specified), or will be the current workflow
     workflow: workflow_name.yml
     # Optional, the status or conclusion of a completed workflow to search for
     # Can be one of a workflow conclusion:

--- a/action.yml
+++ b/action.yml
@@ -10,8 +10,11 @@ inputs:
     required: false
     default: ${{github.token}}
   workflow:
-    description: Workflow name
-    required: true
+    description: |
+      Workflow name.
+
+      If not specified, will be inferred from run_id (if run_id is specified), or will be the current workflow
+    required: false
   workflow_conclusion:
     description: |
       Wanted status or conclusion to search for in recent runs

--- a/main.js
+++ b/main.js
@@ -12,11 +12,11 @@ function inform(key, val) {
 async function main() {
     try {
         const token = core.getInput("github_token", { required: true })
-        const workflow = core.getInput("workflow", { required: true })
         const [owner, repo] = core.getInput("repo", { required: true }).split("/")
         const path = core.getInput("path", { required: true })
         const name = core.getInput("name")
         const skipUnpack = core.getInput("skip_unpack")
+        let workflow = core.getInput("workflow")
         let workflowConclusion = core.getInput("workflow_conclusion")
         let pr = core.getInput("pr")
         let commit = core.getInput("commit")
@@ -30,10 +30,20 @@ async function main() {
 
         const client = github.getOctokit(token)
 
+        core.info(`==> Repository: ${owner}/${repo}`)
         core.info(`==> Artifact name: ${name}`)
         core.info(`==> Local path: ${path}`)
+
+        if (!workflow) {
+            const run = await client.rest.actions.getWorkflowRun({
+                owner: owner,
+                repo: repo,
+                run_id: runID || github.context.runId,
+            });
+            workflow = run.data.workflow_id
+        }
+
         core.info(`==> Workflow name: ${workflow}`)
-        core.info(`==> Repository: ${owner}/${repo}`)
         core.info(`==> Workflow conclusion: ${workflowConclusion}`)
 
         const uniqueInputSets = [


### PR DESCRIPTION
`run_id`s are unique across workflows. So `workflow` id can be inferred from `run_id`.

And when neither `run_id` nor `workflow` are specified, current workflow can be used as a fallback.

Because `workflow` was previously a required input, this change shouldn't break any existing pipeline.