### PR TITLE
docs: describe how to ignore workflow_conclusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Let's suppose you have a workflow with a job in it that at the end uploads an ar
     #   "failure", "success", "neutral", "cancelled", "skipped", "timed_out", "action_required"
     # Or a workflow status:
     #   "completed", "in_progress", "queued"
-    # Use the emtpy string ("") to ignore status or conclusion in the search
+    # Use the empty string ("") to ignore status or conclusion in the search
     workflow_conclusion: success
     # Optional, will get head commit SHA
     pr: ${{github.event.pull_request.number}}

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Let's suppose you have a workflow with a job in it that at the end uploads an ar
     #   "failure", "success", "neutral", "cancelled", "skipped", "timed_out", "action_required"
     # Or a workflow status:
     #   "completed", "in_progress", "queued"
+    # Use the emtpy string ("") to ignore status or conclusion in the search
     workflow_conclusion: success
     # Optional, will get head commit SHA
     pr: ${{github.event.pull_request.number}}


### PR DESCRIPTION
Given that the default value of the `workflow_conclusion` parameter is `success`, adding a description on how to ignore the conclusion altogether lets the user skip sipping through action source code or issues to figure out how to ignore it. Relates to #176.