### PR TITLE
feat: add additional input to define how to fail the action

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Let's suppose you have a workflow with a job in it that at the end uploads an ar
 
 ```yaml
 - name: Download artifact
+  id: download-artifact
   uses: dawidd6/action-download-artifact@v2
   with:
     # Optional, GitHub token, a Personal Access Token with `public_repo` scope if needed
@@ -65,3 +66,15 @@ Let's suppose you have a workflow with a job in it that at the end uploads an ar
     # default ignore
     if_no_artifact_found: false
 ```
+
+## Output
+
+The `found_artifact` step output contains a boolean value indicating whether an artifact was found.
+```yaml
+steps:
+  - id: download-artifact
+    uses: dawidd6/action-download-artifact@v2
+
+  - name: 'use artifact'
+    if: steps.download-artifact.found_artifact
+    run: echo "Found artifact"

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Let's suppose you have a workflow with a job in it that at the end uploads an ar
     # can be one of:
     #  "fail", "warn", "ignore"
     # default ignore
-    if_no_artifact_found: false
+    if_no_artifact_found: fail
 ```
 
 ## Output

--- a/README.md
+++ b/README.md
@@ -59,4 +59,9 @@ Let's suppose you have a workflow with a job in it that at the end uploads an ar
     # Optional, choose to skip unpacking the downloaded artifact(s)
     # default false
     skip_unpack: false
+    # Optional, choose how to exit the action if no artifact is found
+    # can be one of:
+    #  "fail", "warn", "ignore"
+    # default ignore
+    if_no_files_found: false
 ```

--- a/README.md
+++ b/README.md
@@ -63,5 +63,5 @@ Let's suppose you have a workflow with a job in it that at the end uploads an ar
     # can be one of:
     #  "fail", "warn", "ignore"
     # default ignore
-    if_no_files_found: false
+    if_no_artifact_found: false
 ```

--- a/action.yml
+++ b/action.yml
@@ -63,6 +63,10 @@ inputs:
   dry_run:
     description: Check the existence of artifact(s) without downloading.
     required: false
+  if_no_files_found: false
+    required: false
+    description: choose how to exit the action if no artifact is found
+    default: "ignore"
 outputs:
   error_message:
     description: The error message, if an error occurs

--- a/action.yml
+++ b/action.yml
@@ -66,7 +66,7 @@ inputs:
   if_no_artifact_found:
     required: false
     description: choose how to exit the action if no artifact is found
-    default: "ignore"
+    default: "fail"
 outputs:
   error_message:
     description: The error message, if an error occurs

--- a/action.yml
+++ b/action.yml
@@ -63,7 +63,7 @@ inputs:
   dry_run:
     description: Check the existence of artifact(s) without downloading.
     required: false
-  if_no_files_found:
+  if_no_artifact_found:
     required: false
     description: choose how to exit the action if no artifact is found
     default: "ignore"

--- a/action.yml
+++ b/action.yml
@@ -72,6 +72,8 @@ outputs:
     description: The error message, if an error occurs
   dry_run:
     description: Boolean output which is true if the dry run was successful and false otherwise.
+  found_artifact:
+    description: Boolean output which is true if the artifact was found and false otherwise.
 runs:
   using: node16
   main: main.js

--- a/action.yml
+++ b/action.yml
@@ -63,7 +63,7 @@ inputs:
   dry_run:
     description: Check the existence of artifact(s) without downloading.
     required: false
-  if_no_files_found: false
+  if_no_files_found:
     required: false
     description: choose how to exit the action if no artifact is found
     default: "ignore"

--- a/main.js
+++ b/main.js
@@ -141,7 +141,7 @@ async function main() {
         }
 
         if (!runID) {
-            setExitMessage("no matching workflow run found with any artifacts?")
+            setExitMessage(ifNoArtifactFound, "no matching workflow run found with any artifacts?")
             return
         }
 
@@ -169,9 +169,11 @@ async function main() {
         if (dryRun) {
             if (artifacts.length == 0) {
                 core.setOutput("dry_run", false)
+                core.setOutput("found_artifact", false)
                 return
             } else {
                 core.setOutput("dry_run", true)
+                core.setOutput("found_artifact", true)
                 core.info('==> (found) Artifacts')
                 for (const artifact of artifacts) {
                     const size = filesize(artifact.size_in_bytes, { base: 10 })
@@ -185,11 +187,13 @@ async function main() {
         }
 
         if (artifacts.length == 0) {
-            setExitMessage("no artifacts found")
+            setExitMessage(ifNoArtifactFound, "no artifacts found")
             return
         }
 
+        core.setOutput("found_artifact", true)
         for (const artifact of artifacts) {
+
             core.info(`==> Artifact: ${artifact.id}`)
 
             const size = filesize(artifact.size_in_bytes, { base: 10 })
@@ -227,12 +231,14 @@ async function main() {
             core.endGroup()
         }
     } catch (error) {
+        core.setOutput("found_artifact", false)
         core.setOutput("error_message", error.message)
         core.setFailed(error.message)
     }
 
-    function setExitMessage(message) {
-        switch (ifNoFilesFound) {
+    function setExitMessage(ifNoArtifactFound, message) {
+        core.setOutput("found_artifact", false)
+        switch (ifNoArtifactFound) {
             case "fail":
                 core.setFailed(message)
                 break

--- a/main.js
+++ b/main.js
@@ -40,7 +40,7 @@ async function main() {
                 owner: owner,
                 repo: repo,
                 run_id: runID || github.context.runId,
-            });
+            })
             workflow = run.data.workflow_id
         }
 
@@ -142,7 +142,7 @@ async function main() {
 
         if (!runID) {
             setExitMessage("no matching workflow run found with any artifacts?")
-            return;
+            return
         }
 
         let artifacts = await client.paginate(client.rest.actions.listWorkflowRunArtifacts, {
@@ -186,7 +186,7 @@ async function main() {
 
         if (artifacts.length == 0) {
             setExitMessage("no artifacts found")
-            return;
+            return
         }
 
         for (const artifact of artifacts) {

--- a/main.js
+++ b/main.js
@@ -16,7 +16,7 @@ async function main() {
         const path = core.getInput("path", { required: true })
         const name = core.getInput("name")
         const skipUnpack = core.getInput("skip_unpack")
-        const ifNoFilesFound = core.getInput("if_no_files_found")
+        const ifNoArtifactFound = core.getInput("if_no_artifact_found")
         let workflow = core.getInput("workflow")
         let workflowConclusion = core.getInput("workflow_conclusion")
         let pr = core.getInput("pr")


### PR DESCRIPTION
this adds an additional input `if_no_files_found` which follows the semantic of `upload-artifact`.

the proposes solution in the issue comments to use `continue-on-error` has the ugly side-effect of showing a red warning in the workflow summary.
as I'm trying to train the developers to actually look at this summary in order to watch out for lint warning, they should not see red false-negative results in this list.