### PR TITLE
Use `commit` as `head_sha` to reduce number of API calls

### DIFF
--- a/.github/workflows/download.yml
+++ b/.github/workflows/download.yml
@@ -58,6 +58,21 @@ jobs:
           pr: ${{github.event.pull_request.number}}
       - name: Test
         run: cat artifact/sha | grep $GITHUB_SHA
+  download-commit:
+    runs-on: ubuntu-latest
+    needs: wait
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Download
+        uses: ./
+        with:
+          workflow: upload.yml
+          name: artifact
+          path: artifact
+          commit: ${{github.sha}}
+      - name: Test
+        run: cat artifact/sha | grep $GITHUB_SHA
   download-multiple:
     runs-on: ubuntu-latest
     needs: wait

--- a/.github/workflows/download.yml
+++ b/.github/workflows/download.yml
@@ -70,7 +70,7 @@ jobs:
           workflow: upload.yml
           name: artifact
           path: artifact
-          commit: ${{github.sha}}
+          commit: ${{ github.event.workflow_run.head_sha }}
       - name: Test
         run: cat artifact/sha | grep $GITHUB_SHA
   download-multiple:

--- a/main.js
+++ b/main.js
@@ -109,12 +109,10 @@ async function main() {
                 workflow_id: workflow,
                 ...(branch ? { branch } : {}),
                 ...(event ? { event } : {}),
+                ...(commit ? { head_sha: commit } : {}),
             }
             )) {
                 for (const run of runs.data) {
-                    if (commit && run.head_sha != commit) {
-                        continue
-                    }
                     if (runNumber && run.run_number != runNumber) {
                         continue
                     }


### PR DESCRIPTION
Less results -> less pagination -> less API calls.
Maybe a bit faster even.

https://octokit.github.io/rest.js/v19#actions-list-workflow-runs

https://github.com/dawidd6/action-download-artifact/issues/226