### PR TITLE
Add regexp filter for artifact name

### DIFF
--- a/.github/workflows/download.yml
+++ b/.github/workflows/download.yml
@@ -221,7 +221,7 @@ jobs:
       - name: Test
         run: |
           find .
-          cat artifact1/sha1 | grep $GITHUB_SHA
-          cat artifact2/sha2 | grep $GITHUB_SHA
-          ! test -d artifact/artifact
-          ! test -f artifact.zip
+          cat artifact/artifact1/sha1 | grep $GITHUB_SHA
+          cat artifact/artifact2/sha2 | grep $GITHUB_SHA
+          ! test -d artifact/artifact/artifact
+          ! test -f artifact/artifact.zip

--- a/.github/workflows/download.yml
+++ b/.github/workflows/download.yml
@@ -102,7 +102,6 @@ jobs:
           name_is_regexp: true
       - name: Test
         run: |
-          find .
           cat artifact1/sha1 | grep $GITHUB_SHA
           cat artifact2/sha2 | grep $GITHUB_SHA
           ! test -d artifact/artifact
@@ -220,7 +219,6 @@ jobs:
           search_artifacts: true
       - name: Test
         run: |
-          find .
           cat artifact/artifact1/sha1 | grep $GITHUB_SHA
           cat artifact/artifact2/sha2 | grep $GITHUB_SHA
           ! test -d artifact/artifact/artifact

--- a/.github/workflows/download.yml
+++ b/.github/workflows/download.yml
@@ -102,6 +102,7 @@ jobs:
           name_is_regexp: true
       - name: Test
         run: |
+          find .
           cat artifact1/sha1 | grep $GITHUB_SHA
           cat artifact2/sha2 | grep $GITHUB_SHA
           ! test -d artifact/artifact
@@ -219,6 +220,7 @@ jobs:
           search_artifacts: true
       - name: Test
         run: |
+          find .
           cat artifact1/sha1 | grep $GITHUB_SHA
           cat artifact2/sha2 | grep $GITHUB_SHA
           ! test -d artifact/artifact

--- a/.github/workflows/download.yml
+++ b/.github/workflows/download.yml
@@ -88,6 +88,24 @@ jobs:
           cat artifact/sha | grep $GITHUB_SHA
           cat artifact1/sha1 | grep $GITHUB_SHA
           cat artifact2/sha2 | grep $GITHUB_SHA
+  download-regexp:
+    runs-on: ubuntu-latest
+    needs: wait
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Download
+        uses: ./
+        with:
+          workflow: upload.yml
+          name: artifact.
+          name_is_regexp: true
+      - name: Test
+        run: |
+          cat artifact1/sha1 | grep $GITHUB_SHA
+          cat artifact2/sha2 | grep $GITHUB_SHA
+          ! test -d artifact/artifact
+          ! test -f artifact.zip
   download-empty-conclusion:
     runs-on: ubuntu-latest
     needs: wait
@@ -185,3 +203,23 @@ jobs:
           search_artifacts: true
       - name: Test
         run: cat artifact/sha | grep $GITHUB_SHA
+  download-regexp-with-search-artifacts:
+    runs-on: ubuntu-latest
+    needs: wait
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Download
+        uses: ./
+        with:
+          workflow: upload.yml
+          name: artifact.
+          name_is_regexp: true
+          path: artifact
+          search_artifacts: true
+      - name: Test
+        run: |
+          cat artifact1/sha1 | grep $GITHUB_SHA
+          cat artifact2/sha2 | grep $GITHUB_SHA
+          ! test -d artifact/artifact
+          ! test -f artifact.zip

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Let's suppose you have a workflow with a job in it that at the end uploads an ar
     # will download only those artifacts with a name that matches this regular expression
     # https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_expressions
     # ignored if name is given
-    filter: /artifact_.*/
+    filter: ^artifact_.*
     # Optional, a directory where to extract artifact(s), defaults to the current directory
     path: extract_here
     # Optional, defaults to current repo

--- a/README.md
+++ b/README.md
@@ -45,12 +45,12 @@ Let's suppose you have a workflow with a job in it that at the end uploads an ar
     # will download all artifacts if not specified
     # and extract them into respective subdirectories
     # https://github.com/actions/download-artifact#download-all-artifacts
-    name: artifact_name
-    # Optional, regexp filter on uploaded artifact name
+    # is treated as a regular expression if input name_is_regexp is true
     # will download only those artifacts with a name that matches this regular expression
     # https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_expressions
-    # ignored if name is given
-    filter: ^artifact_.*
+    name: artifact_name
+    # Optional, name is treated as a regular expression if set true
+    name_is_regexp: true
     # Optional, a directory where to extract artifact(s), defaults to the current directory
     path: extract_here
     # Optional, defaults to current repo
@@ -58,7 +58,7 @@ Let's suppose you have a workflow with a job in it that at the end uploads an ar
     # Optional, check the workflow run to whether it has an artifact
     # then will get the last available artifact from the previous workflow
     # default false, just try to download from the last one
-    check_artifacts:  false
+    check_artifacts: false
     # Optional, search for the last workflow run whose stored an artifact named as in `name` input
     # default false
     search_artifacts: false

--- a/README.md
+++ b/README.md
@@ -46,6 +46,11 @@ Let's suppose you have a workflow with a job in it that at the end uploads an ar
     # and extract them into respective subdirectories
     # https://github.com/actions/download-artifact#download-all-artifacts
     name: artifact_name
+    # Optional, regexp filter on uploaded artifact name
+    # will download only those artifacts with a name that matches this regular expression
+    # https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_expressions
+    # ignored if name is given
+    filter: /artifact_.*/
     # Optional, a directory where to extract artifact(s), defaults to the current directory
     path: extract_here
     # Optional, defaults to current repo

--- a/action.yml
+++ b/action.yml
@@ -47,6 +47,10 @@ inputs:
   name:
     description: Artifact name (download all artifacts if not specified)
     required: false
+  name_is_regexp:
+    description: Treat artifact name as a regular expression and download only artifacts with matching names
+    required: false
+    default: "false"
   path:
     description: Where to unpack the artifact
     required: false

--- a/action.yml
+++ b/action.yml
@@ -50,7 +50,7 @@ inputs:
   name_is_regexp:
     description: Treat artifact name as a regular expression and download only artifacts with matching names
     required: false
-    default: "false"
+    default: false
   path:
     description: Where to unpack the artifact
     required: false

--- a/main.js
+++ b/main.js
@@ -239,7 +239,7 @@ async function main() {
                 continue
             }
 
-            const dir = name ? path : pathname.join(path, artifact.name)
+            const dir = name && !nameIsRegExp ? path : pathname.join(path, artifact.name)
 
             fs.mkdirSync(dir, { recursive: true })
 

--- a/main.js
+++ b/main.js
@@ -131,7 +131,10 @@ async function main() {
                         }
                         if (searchArtifacts) {
                             const artifact = artifacts.find((artifact) => {
-                                return nameIsRegExp && artifact.name.match(name) !== null || artifact.name == name
+                                if (nameIsRegExp) {
+                                    return artifact.name.match(name) !== null
+                                }
+                                return artifact.name == name
                             })
                             if (!artifact) {
                                 continue
@@ -170,7 +173,10 @@ async function main() {
         // One artifact if 'name' input is specified, one or more if `name` is a regular expression, all otherwise.
         if (name) {
             filtered = artifacts.filter((artifact) => {
-                return nameIsRegExp && artifact.name.match(name) !== null || artifact.name == name
+                if (nameIsRegExp) {
+                    return artifact.name.match(name) !== null
+                }
+                return artifact.name == name
             })
             if (filtered.length == 0) {
                 core.info(`==> (not found) Artifact: ${name}`)

--- a/main.js
+++ b/main.js
@@ -25,6 +25,7 @@ async function main() {
         const [owner, repo] = core.getInput("repo", { required: true }).split("/")
         const path = core.getInput("path", { required: true })
         const name = core.getInput("name")
+        const filter = core.getInput("filter")
         const skipUnpack = core.getBooleanInput("skip_unpack")
         const ifNoArtifactFound = core.getInput("if_no_artifact_found")
         let workflow = core.getInput("workflow")
@@ -130,7 +131,7 @@ async function main() {
                         }
                         if (searchArtifacts) {
                             const artifact = artifacts.find((artifact) => {
-                                return artifact.name == name
+                                return name && artifact.name == name || artifact.name.match(filter) !== null
                             })
                             if (!artifact) {
                                 continue
@@ -166,10 +167,10 @@ async function main() {
             run_id: runID,
         })
 
-        // One artifact or all if `name` input is not specified.
-        if (name) {
+        // One artifact if 'name' input is specified, multiple if `filter` is specified, all otherwise.
+        if (name || filter) {
             filtered = artifacts.filter((artifact) => {
-                return artifact.name == name
+                return name && artifact.name == name || artifact.name.match(filter) !== null
             })
             if (filtered.length == 0) {
                 core.info(`==> (not found) Artifact: ${name}`)

--- a/main.js
+++ b/main.js
@@ -25,7 +25,8 @@ async function main() {
         const [owner, repo] = core.getInput("repo", { required: true }).split("/")
         const path = core.getInput("path", { required: true })
         const name = core.getInput("name")
-        const filter = core.getInput("filter") ? new RegExp(core.getInput("filter")) : null
+        const nameIsRegExp = core.getBooleanInput("name_is_regexp")
+        const nameRegExp = nameIsRegExp ? new RegExp(name) : null
         const skipUnpack = core.getBooleanInput("skip_unpack")
         const ifNoArtifactFound = core.getInput("if_no_artifact_found")
         let workflow = core.getInput("workflow")
@@ -131,7 +132,7 @@ async function main() {
                         }
                         if (searchArtifacts) {
                             const artifact = artifacts.find((artifact) => {
-                                return name && artifact.name == name || artifact.name.match(filter) !== null
+                                return nameIsRegExp && artifact.name.match(name) !== null || artifact.name == name
                             })
                             if (!artifact) {
                                 continue
@@ -167,10 +168,10 @@ async function main() {
             run_id: runID,
         })
 
-        // One artifact if 'name' input is specified, multiple if `filter` is specified, all otherwise.
-        if (name || filter) {
+        // One artifact if 'name' input is specified, one or more if `name` is a regular expression, all otherwise.
+        if (name) {
             filtered = artifacts.filter((artifact) => {
-                return name && artifact.name == name || artifact.name.match(filter) !== null
+                return nameIsRegExp && artifact.name.match(name) !== null || artifact.name == name
             })
             if (filtered.length == 0) {
                 core.info(`==> (not found) Artifact: ${name}`)

--- a/main.js
+++ b/main.js
@@ -26,7 +26,6 @@ async function main() {
         const path = core.getInput("path", { required: true })
         const name = core.getInput("name")
         const nameIsRegExp = core.getBooleanInput("name_is_regexp")
-        const nameRegExp = nameIsRegExp ? new RegExp(name) : null
         const skipUnpack = core.getBooleanInput("skip_unpack")
         const ifNoArtifactFound = core.getInput("if_no_artifact_found")
         let workflow = core.getInput("workflow")

--- a/main.js
+++ b/main.js
@@ -25,7 +25,7 @@ async function main() {
         const [owner, repo] = core.getInput("repo", { required: true }).split("/")
         const path = core.getInput("path", { required: true })
         const name = core.getInput("name")
-        const filter = core.getInput("filter")
+        const filter = core.getInput("filter") ? new RegExp(core.getInput("filter")) : null
         const skipUnpack = core.getBooleanInput("skip_unpack")
         const ifNoArtifactFound = core.getInput("if_no_artifact_found")
         let workflow = core.getInput("workflow")


### PR DESCRIPTION
Currently, either one artifact (by name) or all artifacts can be downloaded.

This adds option `filter`, which is used as a regular expression to match the artifact names. Only those artifacts where the name matches the regular expression are downloaded.