### PR TITLE
Attempt to ensure that we download the latest artifact

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -63,6 +63,10 @@ inputs:
     description: Search workflow runs for artifact with specified name
     required: false
     default: false
+  ensure_latest:
+    description: Ensures that we are using the latest available artifact
+    required: false
+    default: false
   skip_unpack:
     description: Choose to skip unpacking the downloaded artifact(s)
     required: false
@@ -74,7 +78,7 @@ inputs:
     required: false
     description: |
       Choose how to exit the action if no artifact is found
-      
+
       fail, warn or ignore
     default: fail
 outputs:

--- a/main.js
+++ b/main.js
@@ -104,7 +104,7 @@ async function main() {
 
         if (!runID) {
             // Note that the runs are returned in most recent first order.
-            for await (const runs of client.paginate.iterator(client.rest.actions.listWorkflowRuns, {
+            for await (const runs of client.paginate.iterator(client.rest.actions.listWorkflowRunsForRepo, {
                 owner: owner,
                 repo: repo,
                 workflow_id: workflow,

--- a/main.js
+++ b/main.js
@@ -38,6 +38,7 @@ async function main() {
         let runNumber = core.getInput("run_number")
         let checkArtifacts = core.getBooleanInput("check_artifacts")
         let searchArtifacts = core.getBooleanInput("search_artifacts")
+        let ensureLatest = core.getBooleanInput("ensure_latest")
         let dryRun = core.getInput("dry_run")
 
         const client = github.getOctokit(token)
@@ -103,7 +104,8 @@ async function main() {
         }
 
         if (!runID) {
-            // Note that the runs are returned in most recent first order.
+            // Note that the runs are returned (roughly) in most recent first order. However, for repos
+            // with lots and lots of runs, this may not always be the case (hence why we need ensureLatest).
             for await (const runs of client.paginate.iterator(client.rest.actions.listWorkflowRunsForRepo, {
                 owner: owner,
                 repo: repo,
@@ -113,6 +115,7 @@ async function main() {
                 ...(commit ? { head_sha: commit } : {}),
             }
             )) {
+                let runCreatedAt = null;
                 for (const run of runs.data) {
                     if (runNumber && run.run_number != runNumber) {
                         continue
@@ -141,12 +144,20 @@ async function main() {
                             }
                         }
                     }
+                    if (ensureLatest) {
+                        if (runCreatedAt === null || ((new Date(run.created_at)) > (new Date(runCreatedAt)))) {
+                            runID = run.id;
+                            runCreatedAt = run.created_at;
+                        }
+                        continue;
+                    }
                     runID = run.id
-                    core.info(`==> (found) Run ID: ${runID}`)
-                    core.info(`==> (found) Run date: ${run.created_at}`)
+                    runCreatedAt = run.created_at;
                     break
                 }
                 if (runID) {
+                    core.info(`==> (found) Run ID: ${runID}`)
+                    core.info(`==> (found) Run date: ${runCreatedAt}`)
                     break
                 }
             }
@@ -215,7 +226,7 @@ async function main() {
         }
 
         core.setOutput("found_artifact", true)
-        
+
         for (const artifact of artifacts) {
             core.info(`==> Artifact: ${artifact.id}`)
 
@@ -270,7 +281,7 @@ async function main() {
 
     function setExitMessage(ifNoArtifactFound, message) {
         core.setOutput("found_artifact", false)
-        
+
         switch (ifNoArtifactFound) {
             case "fail":
                 core.setFailed(message)


### PR DESCRIPTION
This fixes issue #240 for me!

When switching from 'listWorkflowRuns' to the 'listWorkflowRunsForRepo' end-point, it's returning the workflow runs in reverse chronological order (ie. newest to oldest), which means that newer artifacts are favored over older ones.