### PR TITLE
fix: ignore forks

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,4 +72,8 @@ Let's suppose you have a workflow with a job in it that at the end uploads an ar
     #  "fail", "warn", "ignore"
     # default fail
     if_no_artifact_found: fail
+    # Optional, ignore forks when searching for artifacts
+    # when a branch is specified, this is defaulted to false.
+    # default true
+    allow_forks: false
 ```

--- a/README.md
+++ b/README.md
@@ -73,7 +73,6 @@ Let's suppose you have a workflow with a job in it that at the end uploads an ar
     # default fail
     if_no_artifact_found: fail
     # Optional, ignore forks when searching for artifacts
-    # when a branch is specified, this is defaulted to false.
     # default true
     allow_forks: false
 ```

--- a/action.yml
+++ b/action.yml
@@ -58,6 +58,7 @@ inputs:
   allow_forks:
     description: Allow forks
     required: false
+    default: true
   check_artifacts:
     description: Check workflow run whether it has an artifact
     required: false

--- a/action.yml
+++ b/action.yml
@@ -55,6 +55,10 @@ inputs:
     description: Where to unpack the artifact
     required: false
     default: "./"
+  allow_forks:
+    description: Allow forks
+    required: false
+    default: true
   check_artifacts:
     description: Check workflow run whether it has an artifact
     required: false

--- a/action.yml
+++ b/action.yml
@@ -58,7 +58,6 @@ inputs:
   allow_forks:
     description: Allow forks
     required: false
-    default: true
   check_artifacts:
     description: Check workflow run whether it has an artifact
     required: false

--- a/main.js
+++ b/main.js
@@ -38,7 +38,7 @@ async function main() {
         let runNumber = core.getInput("run_number")
         let checkArtifacts = core.getBooleanInput("check_artifacts")
         let searchArtifacts = core.getBooleanInput("search_artifacts")
-        let hasAllowForks = core.getInput("allow_forks") !== ""
+        let hasAllowForksInput = core.getInput("allow_forks") !== ""
         let dryRun = core.getInput("dry_run")
 
         const client = github.getOctokit(token)
@@ -107,7 +107,7 @@ async function main() {
         let allowForks = !branch
 
         // `allow_forks` overrides any other logic
-        if (hasAllowForks) {
+        if (hasAllowForksInput) {
             allowForks = core.getBooleanInput("allow_forks")
         }
 

--- a/main.js
+++ b/main.js
@@ -38,7 +38,13 @@ async function main() {
         let runNumber = core.getInput("run_number")
         let checkArtifacts = core.getBooleanInput("check_artifacts")
         let searchArtifacts = core.getBooleanInput("search_artifacts")
+        let allowForks = core.getBooleanInput("allow_forks")
         let dryRun = core.getInput("dry_run")
+
+        // Using allow_forks lets the user accept any fork, in any situation,
+        // But if it's not set, we forbid forks if the user is trying to download
+        // artifacts from a given branch.
+        const willAcceptForks = allowForks || !branch;
 
         const client = github.getOctokit(token)
 
@@ -120,7 +126,7 @@ async function main() {
                     if (workflowConclusion && (workflowConclusion != run.conclusion && workflowConclusion != run.status)) {
                         continue
                     }
-                    if (run.head_repository.full_name !== `${owner}/${repo}`) {
+                    if (!willAcceptForks && run.head_repository.full_name !== `${owner}/${repo}`) {
                         core.info(`==> Skipping run from fork: ${run.head_repository.full_name}`)
                         continue;
                     }

--- a/main.js
+++ b/main.js
@@ -38,7 +38,7 @@ async function main() {
         let runNumber = core.getInput("run_number")
         let checkArtifacts = core.getBooleanInput("check_artifacts")
         let searchArtifacts = core.getBooleanInput("search_artifacts")
-        let hasAllowForksInput = core.getInput("allow_forks") !== ""
+        const allowForks = core.getBooleanInput("allow_forks")
         let dryRun = core.getInput("dry_run")
 
         const client = github.getOctokit(token)
@@ -101,14 +101,6 @@ async function main() {
 
         if (runNumber) {
             core.info(`==> Run number: ${runNumber}`)
-        }
-
-        // We allow forks by default, except when a branch is requested
-        let allowForks = !branch
-
-        // `allow_forks` overrides any other logic
-        if (hasAllowForksInput) {
-            allowForks = core.getBooleanInput("allow_forks")
         }
 
         core.info(`==> Allow forks: ${allowForks}`)

--- a/main.js
+++ b/main.js
@@ -120,6 +120,10 @@ async function main() {
                     if (workflowConclusion && (workflowConclusion != run.conclusion && workflowConclusion != run.status)) {
                         continue
                     }
+                    if (run.head_repository.full_name !== `${owner}/${repo}`) {
+                        core.info(`==> Skipping run from fork: ${run.head_repository.full_name}`)
+                        continue;
+                    }
                     if (checkArtifacts || searchArtifacts) {
                         let artifacts = await client.paginate(client.rest.actions.listWorkflowRunArtifacts, {
                             owner: owner,

--- a/main.js
+++ b/main.js
@@ -44,7 +44,7 @@ async function main() {
         // Using allow_forks lets the user accept any fork, in any situation,
         // But if it's not set, we forbid forks if the user is trying to download
         // artifacts from a given branch.
-        const willAcceptForks = allowForks || !branch;
+        const willAcceptForks = allowForks || !branch
 
         const client = github.getOctokit(token)
 
@@ -128,7 +128,7 @@ async function main() {
                     }
                     if (!willAcceptForks && run.head_repository.full_name !== `${owner}/${repo}`) {
                         core.info(`==> Skipping run from fork: ${run.head_repository.full_name}`)
-                        continue;
+                        continue
                     }
                     if (checkArtifacts || searchArtifacts) {
                         let artifacts = await client.paginate(client.rest.actions.listWorkflowRunArtifacts, {


### PR DESCRIPTION
Contributes to https://github.com/dawidd6/action-download-artifact/issues/249

When working with the GitHub API, a run originating from a fork might still have the same branch name (e.g., master) as the parent repository. To filter out runs from forks, we check the `head_repository` attribute of the run. This attribute contains information about the repository where the head of the pull request is stored.