### PR TITLE
Optionally search for workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ Let's suppose you have a workflow with a job in it that at the end uploads an ar
     # Optional, workflow file name or ID
     # If not specified, will be inferred from run_id (if run_id is specified), or will be the current workflow
     workflow: workflow_name.yml
+    # If no workflow is set and workflow_search set to true, then the most recent workflow matching
+    # all other criteria will be looked up instead of using the current workflow
+    workflow_search: false
     # Optional, the status or conclusion of a completed workflow to search for
     # Can be one of a workflow conclusion:
     #   "failure", "success", "neutral", "cancelled", "skipped", "timed_out", "action_required"

--- a/action.yml
+++ b/action.yml
@@ -19,7 +19,7 @@ inputs:
     description: |
       Wanted status or conclusion to search for in recent runs
 
-      https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#list-workflow-runs
+      https://docs.github.com/de/rest/actions/workflow-runs?apiVersion=2022-11-28#list-workflow-runs-for-a-workflow
     required: false
     default: success
   repo:

--- a/action.yml
+++ b/action.yml
@@ -78,7 +78,7 @@ inputs:
     required: false
     description: |
       Choose how to exit the action if no artifact is found
-      
+
       fail, warn or ignore
     default: fail
 outputs:

--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,13 @@ inputs:
 
       If not specified, will be inferred from run_id (if run_id is specified), or will be the current workflow
     required: false
+  workflow_search:
+    description: |
+      Most recent workflow matching all other criteria will be looked up instead of using the current workflow
+
+      https://docs.github.com/de/rest/actions/workflow-runs?apiVersion=2022-11-28#list-workflow-runs-for-a-repository
+    required: false
+    default: false
   workflow_conclusion:
     description: |
       Wanted status or conclusion to search for in recent runs

--- a/main.js
+++ b/main.js
@@ -222,7 +222,7 @@ async function main() {
         }
 
         core.setOutput("found_artifact", true)
-        
+
         for (const artifact of artifacts) {
             core.info(`==> Artifact: ${artifact.id}`)
 
@@ -277,7 +277,7 @@ async function main() {
 
     function setExitMessage(ifNoArtifactFound, message) {
         core.setOutput("found_artifact", false)
-        
+
         switch (ifNoArtifactFound) {
             case "fail":
                 core.setFailed(message)


### PR DESCRIPTION
When no workflow is set, until now the current workflow has been chosen. But the workflow we get the artifact from could be another one determined by other criteria like the branch and the artifact name.
    
We provide a new option `workflow_search`, that if set, allows us to search for the workflow repo-wide according to the other provided data.

This is a failing job with upstream action v3: https://github.com/romangg/theseus-ship/actions/runs/7904208512/job/21573949899

This is a successful job ran against the version from this PR: https://github.com/romangg/theseus-ship/actions/runs/7906156620/job/21581226467

In my case the workflows are named differently depending on them being a scheduled workflow or a workflow on push.

This new option defaulting to `false` should be compatible with current usage of the action.