### PR TITLE
Head sha revert

### DIFF
--- a/.github/workflows/download.yml
+++ b/.github/workflows/download.yml
@@ -26,6 +26,19 @@ jobs:
           path: artifact
       - name: Test
         run: cat artifact/sha | grep $GITHUB_SHA
+  download-search-workflow:
+    runs-on: ubuntu-latest
+    needs: wait
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Download
+        uses: ./
+        with:
+          name: artifact
+          path: artifact
+      - name: Test
+        run: cat artifact/sha | grep $GITHUB_SHA
   download-branch:
     runs-on: ubuntu-latest
     needs: wait

--- a/main.js
+++ b/main.js
@@ -121,12 +121,10 @@ async function main() {
                 ...(workflow ? { workflow_id: workflow } : {}),
                 ...(branch ? { branch } : {}),
                 ...(event ? { event } : {}),
+                ...(commit ? { head_sha: commit } : {}),
             }
             )) {
                 for (const run of runs.data) {
-                    if (commit && run.head_sha != commit) {
-                        continue
-                    }
                     if (runNumber && run.run_number != runNumber) {
                         continue
                     }


### PR DESCRIPTION
In f6b0bace624032e30a85a8fd9c1a7f8f611f5737 the check on the commit value provided was moved to the body of the function. Instead directly provide it as parameter of the request as it was before, assuming that this might affect the number of requests sent.