### PR TITLE
Read workflow_search input as a boolean (#273)

### DIFF
--- a/.github/workflows/download.yml
+++ b/.github/workflows/download.yml
@@ -37,6 +37,7 @@ jobs:
         with:
           name: artifact
           path: artifact
+          workflow_search: true
       - name: Test
         run: cat artifact/sha | grep $GITHUB_SHA
   download-branch:

--- a/main.js
+++ b/main.js
@@ -38,7 +38,7 @@ async function main() {
         const skipUnpack = core.getBooleanInput("skip_unpack")
         const ifNoArtifactFound = core.getInput("if_no_artifact_found")
         let workflow = core.getInput("workflow")
-        let workflowSearch = core.getInput("workflow_search")
+        let workflowSearch = core.getBooleanInput("workflow_search")
         let workflowConclusion = core.getInput("workflow_conclusion")
         let pr = core.getInput("pr")
         let commit = core.getInput("commit")


### PR DESCRIPTION
In commit f6b0bace624032e30a85a8fd9c1a7f8f611f5737 we added a check for !workflow_search before using the current workflow, but with a string this always evaluates to true.

This results in always searching workflows, and if enough inputs are unspecified it can find the wrong run id.