### PR TITLE
fix: accept expired artifacts with documentation url

### DIFF
--- a/main.js
+++ b/main.js
@@ -253,7 +253,7 @@ async function main() {
                     archive_format: "zip",
                 })
             } catch (error) {
-                if (error.message === "Artifact has expired") {
+                if (error.message.startsWith("Artifact has expired")) {
                     return setExitMessage(ifNoArtifactFound, "no downloadable artifacts found (expired)")
                 } else {
                     throw new Error(error.message)


### PR DESCRIPTION
It seems that, recently, GitHub has started to return the expired artifact error along with a URL with more documentation. This leads to the equality error condition not being satisfied, and the error to be thrown even when the settings ask for errors to be ignored:
```
Run dawidd6/action-download-artifact@v3
==> Repository: eic/EICrecon
==> Artifact name: docs
==> Local path: publishing_docs/pr/1161/
==> Workflow name: .github/workflows/linux-eic-shell.yml
==> Workflow conclusion: completed
==> Commit: 1705fd8d88312862289bb[27](https://github.com/eic/EICrecon/actions/runs/8314077495/job/22751039311#step:2:28)e8b0642be22104362
==> Allow forks: true
==> (found) Run ID: 7040574340
==> (found) Run date: 2023-11-[30](https://github.com/eic/EICrecon/actions/runs/8314077495/job/22751039311#step:2:31)T01:04:01Z
==> Artifact: 1082417363
==> Downloading: docs.zip (10.92 MB)
Error: Artifact has expired - https://docs.github.com/rest/actions/artifacts#download-an-artifact
```
(followed by failed pipeline).

This PR changes the expiration error message to only require the error message to start with "Artifact has expired" and allowing additional text. With this PR, the above pipeline does not return with an error but just ignores the expiration error as intended.