### PR TITLE
Set allow_forks to false by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,9 +75,9 @@ Let's suppose you have a workflow with a job in it that at the end uploads an ar
     #  "fail", "warn", "ignore"
     # default fail
     if_no_artifact_found: fail
-    # Optional, ignore forks when searching for artifacts
-    # default true
-    allow_forks: false
+    # Optional, include forks when searching for artifacts
+    # default false
+    allow_forks: true
 ```
 
 ## Troubleshooting

--- a/action.yml
+++ b/action.yml
@@ -65,7 +65,7 @@ inputs:
   allow_forks:
     description: Allow forks
     required: false
-    default: true
+    default: false
   check_artifacts:
     description: Check workflow run whether it has an artifact
     required: false


### PR DESCRIPTION
Allowing forks should be false by default as forks can be used to upload malicious artifacts.

Closes #288 