### PR TITLE
build(deps): Fix cross-spawn >=7.0.0 <= 7.0.5 vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -970,9 +970,9 @@
       }
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",


### PR DESCRIPTION
There's a vulnerability in `cross-spawn` resolved in 7.0.6: https://security.snyk.io/vuln/SNYK-JS-CROSSSPAWN-8303230

I noticed `node_modules` are committed, but the previous commits don't seem to include them so I only pushed the package-lock.json.
Let me know if I need to include something else.