### PR TITLE
add merge_multiple option

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -92,6 +92,10 @@ inputs:
     description: Use system provided `unzip` utility instead of JS library for unpacking
     required: false
     default: false
+  merge_multiple:
+    description: If multiple artifacts are found with `name_is_regexp` set to `true`, merge them into one directory
+    required: false
+    default: false
 outputs:
   error_message:
     description: The error message, if an error occurs

--- a/main.js
+++ b/main.js
@@ -39,6 +39,7 @@ async function main() {
         const skipUnpack = core.getBooleanInput("skip_unpack")
         const ifNoArtifactFound = core.getInput("if_no_artifact_found")
         const useUnzip = core.getBooleanInput("use_unzip")
+        const mergeMultiple = core.getBooleanInput("merge_multiple")
         let workflow = core.getInput("workflow")
         let workflowSearch = core.getBooleanInput("workflow_search")
         let workflowConclusion = core.getInput("workflow_conclusion")
@@ -268,7 +269,7 @@ async function main() {
                 continue
             }
 
-            const dir = name && !nameIsRegExp ? path : pathname.join(path, artifact.name)
+            const dir = name && (!nameIsRegExp || mergeMultiple) ? path : pathname.join(path, artifact.name)
 
             fs.mkdirSync(dir, { recursive: true })
 


### PR DESCRIPTION
Add merge_multiple option to download all artifacts into the same folder. Essentially does the same as the merge-multiple option from the official download action
https://github.com/actions/download-artifact?tab=readme-ov-file#download-multiple-filtered-artifacts-to-the-same-directory