### PR TITLE
fix: stream artifact downloads to disk to avoid OOM on large artifacts

### DIFF
--- a/main.js
+++ b/main.js
@@ -27,6 +27,8 @@ async function downloadAction(name, path) {
  * Downloads an artifact ZIP directly to disk via Octokit, following redirects
  * without buffering the body in RAM. Non-2xx responses are returned as-is so
  * Octokit can parse and throw the appropriate error (e.g. "Artifact has expired").
+ *
+ * Requires Node.js 18+ for global fetch and Response support (enforce in action.yml).
  */
 async function downloadArtifactToFile(client, owner, repo, artifactId, destPath) {
     await client.request(
@@ -38,7 +40,7 @@ async function downloadArtifactToFile(client, owner, repo, artifactId, destPath)
             archive_format: "zip",
             request: {
                 fetch: async (url, options) => {
-                    const res = await fetch(url, options)
+                    const res = await fetch(url, { ...options, redirect: "follow" })
                     if (!res.ok) return res
                     await pipeline(Readable.fromWeb(res.body), fs.createWriteStream(destPath))
                     return new Response(null, { status: 200, headers: res.headers })
@@ -313,17 +315,18 @@ async function main() {
             if (skipUnpack) continue
 
             // Stream the ZIP to a temp file for extraction.
+            core.startGroup(`==> Extracting: ${artifact.name}.zip`)
             try {
                 const dir = name && (!nameIsRegExp || mergeMultiple) ? path : pathname.join(path, artifact.name)
 
                 fs.mkdirSync(dir, { recursive: true })
 
-                core.startGroup(`==> Extracting: ${artifact.name}.zip`)
                 if (useUnzip) {
                     // Temp file is already on disk – hand it straight to unzip.
                     await exec.exec("unzip", ["-o", destPath, "-d", dir])
                 } else {
-                    // AdmZip file-path constructor: reads entries one at a time, not all into RAM.
+                    // AdmZip loads the entire ZIP into RAM.
+                    // For large artifacts set `use_unzip: true` for streaming extraction.
                     const adm = new AdmZip(destPath)
                     adm.getEntries().forEach((entry) => {
                         const action = entry.isDirectory ? "creating" : "inflating"
@@ -333,8 +336,8 @@ async function main() {
                     })
                     adm.extractAllTo(dir, true)
                 }
-                core.endGroup()
             } finally {
+                core.endGroup()
                 // Always clean up the temp file, even if extraction failed.
                 try { fs.rmSync(destPath) } catch (e) { core.debug(`Failed to remove temp file ${destPath}: ${e.message}`) }
             }

--- a/main.js
+++ b/main.js
@@ -342,17 +342,18 @@ async function main() {
                 }
             }
 
-            // Stream the ZIP straight to a temp file – zero in-memory buffering.
+            // For skip_unpack, stream directly to the final destination – no temp file needed.
+            if (skipUnpack) {
+                fs.mkdirSync(path, { recursive: true })
+                const destZipPath = `${pathname.join(path, artifact.name)}.zip`
+                await streamUrlToFile(downloadUrl, destZipPath)
+                continue
+            }
+
+            // Stream the ZIP to a temp file for extraction.
             const tempZipPath = pathname.join(os.tmpdir(), `artifact-${artifact.id}.zip`)
             try {
                 await streamUrlToFile(downloadUrl, tempZipPath)
-
-                if (skipUnpack) {
-                    fs.mkdirSync(path, { recursive: true })
-                    const destZipPath = `${pathname.join(path, artifact.name)}.zip`
-                    fs.copyFileSync(tempZipPath, destZipPath)
-                    continue
-                }
 
                 const dir = name && (!nameIsRegExp || mergeMultiple) ? path : pathname.join(path, artifact.name)
 

--- a/main.js
+++ b/main.js
@@ -6,6 +6,9 @@ import AdmZip from 'adm-zip'
 import { filesize } from 'filesize'
 import pathname from 'node:path'
 import fs from 'node:fs'
+import https from 'node:https'
+import http from 'node:http'
+import os from 'node:os'
 
 async function downloadAction(name, path) {
     const artifactClient = artifact.create()
@@ -18,6 +21,69 @@ async function downloadAction(name, path) {
         downloadOptions
     )
     core.setOutput("found_artifact", true)
+}
+
+/**
+ * Resolves the final pre-signed download URL for an artifact by letting
+ * Octokit attempt the request with redirects disabled, then following the
+ * Location header ourselves so we never buffer the ZIP body in JS memory.
+ */
+async function getArtifactDownloadUrl(client, owner, repo, artifactId) {
+    try {
+        // Ask Octokit NOT to follow the redirect so we get the Location header.
+        await client.rest.actions.downloadArtifact({
+            owner,
+            repo,
+            artifact_id: artifactId,
+            archive_format: "zip",
+            request: { redirect: "manual" },
+        })
+    } catch (error) {
+        // Octokit throws on 302 when redirects are disabled; grab the URL.
+        if (error.status === 302 && error.response?.headers?.location) {
+            return error.response.headers.location
+        }
+        // Some Octokit versions expose it differently.
+        if (error.response?.headers?.location) {
+            return error.response.headers.location
+        }
+        throw error
+    }
+    throw new Error("Expected a redirect response from downloadArtifact but got none")
+}
+
+/**
+ * Streams a URL (following up to one redirect) straight to a file on disk.
+ * Never holds the full body in Node.js heap memory.
+ */
+function streamUrlToFile(url, destPath) {
+    return new Promise((resolve, reject) => {
+        const dest = fs.createWriteStream(destPath)
+
+        const handleResponse = (res) => {
+            // Follow a single redirect (the pre-signed Azure Blob URL may itself redirect).
+            if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
+                res.resume() // drain the redirect body
+                const redirectUrl = new URL(res.headers.location)
+                const mod = redirectUrl.protocol === 'https:' ? https : http
+                mod.get(res.headers.location, handleResponse).on('error', reject)
+                return
+            }
+            if (res.statusCode !== 200) {
+                reject(new Error(`Unexpected HTTP ${res.statusCode} while downloading artifact from ${url}`))
+                res.resume()
+                return
+            }
+            res.on('error', reject)
+            res.pipe(dest)
+            dest.on('finish', resolve)
+            dest.on('error', reject)
+        }
+
+        const parsedUrl = new URL(url)
+        const mod = parsedUrl.protocol === 'https:' ? https : http
+        mod.get(url, handleResponse).on('error', reject)
+    })
 }
 
 async function getWorkflow(client, owner, repo, runID) {
@@ -264,14 +330,10 @@ async function main() {
 
             core.info(`==> Downloading: ${artifact.name}.zip (${size})`)
 
-            let zip
+            // Resolve the pre-signed download URL without buffering the body.
+            let downloadUrl
             try {
-                zip = await client.rest.actions.downloadArtifact({
-                    owner: owner,
-                    repo: repo,
-                    artifact_id: artifact.id,
-                    archive_format: "zip",
-                })
+                downloadUrl = await getArtifactDownloadUrl(client, owner, repo, artifact.id)
             } catch (error) {
                 if (error.message.startsWith("Artifact has expired")) {
                     return setExitMessage(ifNoArtifactFound, "no downloadable artifacts found (expired)")
@@ -280,33 +342,42 @@ async function main() {
                 }
             }
 
-            if (skipUnpack) {
-                fs.mkdirSync(path, { recursive: true })
-                fs.writeFileSync(`${pathname.join(path, artifact.name)}.zip`, Buffer.from(zip.data), 'binary')
-                continue
+            // Stream the ZIP straight to a temp file – zero in-memory buffering.
+            const tempZipPath = pathname.join(os.tmpdir(), `artifact-${artifact.id}.zip`)
+            try {
+                await streamUrlToFile(downloadUrl, tempZipPath)
+
+                if (skipUnpack) {
+                    fs.mkdirSync(path, { recursive: true })
+                    const destZipPath = `${pathname.join(path, artifact.name)}.zip`
+                    fs.copyFileSync(tempZipPath, destZipPath)
+                    continue
+                }
+
+                const dir = name && (!nameIsRegExp || mergeMultiple) ? path : pathname.join(path, artifact.name)
+
+                fs.mkdirSync(dir, { recursive: true })
+
+                core.startGroup(`==> Extracting: ${artifact.name}.zip`)
+                if (useUnzip) {
+                    // Temp file is already on disk – hand it straight to unzip.
+                    await exec.exec("unzip", ["-o", tempZipPath, "-d", dir])
+                } else {
+                    // AdmZip file-path constructor: reads entries one at a time, not all into RAM.
+                    const adm = new AdmZip(tempZipPath)
+                    adm.getEntries().forEach((entry) => {
+                        const action = entry.isDirectory ? "creating" : "inflating"
+                        const filepath = pathname.join(dir, entry.entryName)
+
+                        core.info(`  ${action}: ${filepath}`)
+                    })
+                    adm.extractAllTo(dir, true)
+                }
+                core.endGroup()
+            } finally {
+                // Always clean up the temp file, even if extraction failed.
+                try { fs.rmSync(tempZipPath) } catch (e) { core.debug(`Failed to remove temp file ${tempZipPath}: ${e.message}`) }
             }
-
-            const dir = name && (!nameIsRegExp || mergeMultiple) ? path : pathname.join(path, artifact.name)
-
-            fs.mkdirSync(dir, { recursive: true })
-
-            core.startGroup(`==> Extracting: ${artifact.name}.zip`)
-            if (useUnzip) {
-                const zipPath = `${pathname.join(dir, artifact.name)}.zip`
-                fs.writeFileSync(zipPath, Buffer.from(zip.data), 'binary')
-                await exec.exec("unzip", [zipPath, "-d", dir])
-                fs.rmSync(zipPath)
-            } else {
-                const adm = new AdmZip(Buffer.from(zip.data))
-                adm.getEntries().forEach((entry) => {
-                    const action = entry.isDirectory ? "creating" : "inflating"
-                    const filepath = pathname.join(dir, entry.entryName)
-
-                    core.info(`  ${action}: ${filepath}`)
-                })
-                adm.extractAllTo(dir, true)
-            }
-            core.endGroup()
         }
     } catch (error) {
         core.setOutput("found_artifact", false)

--- a/main.js
+++ b/main.js
@@ -6,9 +6,9 @@ import AdmZip from 'adm-zip'
 import { filesize } from 'filesize'
 import pathname from 'node:path'
 import fs from 'node:fs'
-import https from 'node:https'
-import http from 'node:http'
 import os from 'node:os'
+import { Readable } from 'node:stream'
+import { pipeline } from 'node:stream/promises'
 
 async function downloadAction(name, path) {
     const artifactClient = artifact.create()
@@ -24,66 +24,28 @@ async function downloadAction(name, path) {
 }
 
 /**
- * Resolves the final pre-signed download URL for an artifact by letting
- * Octokit attempt the request with redirects disabled, then following the
- * Location header ourselves so we never buffer the ZIP body in JS memory.
+ * Downloads an artifact ZIP directly to disk via Octokit, following redirects
+ * without buffering the body in RAM. Non-2xx responses are returned as-is so
+ * Octokit can parse and throw the appropriate error (e.g. "Artifact has expired").
  */
-async function getArtifactDownloadUrl(client, owner, repo, artifactId) {
-    try {
-        // Ask Octokit NOT to follow the redirect so we get the Location header.
-        await client.rest.actions.downloadArtifact({
+async function downloadArtifactToFile(client, owner, repo, artifactId, destPath) {
+    await client.request(
+        "GET /repos/{owner}/{repo}/actions/artifacts/{artifact_id}/{archive_format}",
+        {
             owner,
             repo,
             artifact_id: artifactId,
             archive_format: "zip",
-            request: { redirect: "manual" },
-        })
-    } catch (error) {
-        // Octokit throws on 302 when redirects are disabled; grab the URL.
-        if (error.status === 302 && error.response?.headers?.location) {
-            return error.response.headers.location
+            request: {
+                fetch: async (url, options) => {
+                    const res = await fetch(url, options)
+                    if (!res.ok) return res
+                    await pipeline(Readable.fromWeb(res.body), fs.createWriteStream(destPath))
+                    return new Response(null, { status: 200, headers: res.headers })
+                },
+            },
         }
-        // Some Octokit versions expose it differently.
-        if (error.response?.headers?.location) {
-            return error.response.headers.location
-        }
-        throw error
-    }
-    throw new Error("Expected a redirect response from downloadArtifact but got none")
-}
-
-/**
- * Streams a URL (following up to one redirect) straight to a file on disk.
- * Never holds the full body in Node.js heap memory.
- */
-function streamUrlToFile(url, destPath) {
-    return new Promise((resolve, reject) => {
-        const dest = fs.createWriteStream(destPath)
-
-        const handleResponse = (res) => {
-            // Follow a single redirect (the pre-signed Azure Blob URL may itself redirect).
-            if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
-                res.resume() // drain the redirect body
-                const redirectUrl = new URL(res.headers.location)
-                const mod = redirectUrl.protocol === 'https:' ? https : http
-                mod.get(res.headers.location, handleResponse).on('error', reject)
-                return
-            }
-            if (res.statusCode !== 200) {
-                reject(new Error(`Unexpected HTTP ${res.statusCode} while downloading artifact from ${url}`))
-                res.resume()
-                return
-            }
-            res.on('error', reject)
-            res.pipe(dest)
-            dest.on('finish', resolve)
-            dest.on('error', reject)
-        }
-
-        const parsedUrl = new URL(url)
-        const mod = parsedUrl.protocol === 'https:' ? https : http
-        mod.get(url, handleResponse).on('error', reject)
-    })
+    )
 }
 
 async function getWorkflow(client, owner, repo, runID) {
@@ -330,31 +292,28 @@ async function main() {
 
             core.info(`==> Downloading: ${artifact.name}.zip (${size})`)
 
-            // Resolve the pre-signed download URL without buffering the body.
-            let downloadUrl
-            try {
-                downloadUrl = await getArtifactDownloadUrl(client, owner, repo, artifact.id)
-            } catch (error) {
-                if (error.message.startsWith("Artifact has expired")) {
-                    return setExitMessage(ifNoArtifactFound, "no downloadable artifacts found (expired)")
-                } else {
-                    throw new Error(error.message)
-                }
-            }
+            // Determine the destination path up front.
+            const destPath = skipUnpack
+                ? pathname.join(path, `${artifact.name}.zip`)
+                : pathname.join(os.tmpdir(), `artifact-${artifact.id}.zip`)
 
-            // For skip_unpack, stream directly to the final destination – no temp file needed.
             if (skipUnpack) {
                 fs.mkdirSync(path, { recursive: true })
-                const destZipPath = `${pathname.join(path, artifact.name)}.zip`
-                await streamUrlToFile(downloadUrl, destZipPath)
-                continue
             }
 
-            // Stream the ZIP to a temp file for extraction.
-            const tempZipPath = pathname.join(os.tmpdir(), `artifact-${artifact.id}.zip`)
             try {
-                await streamUrlToFile(downloadUrl, tempZipPath)
+                await downloadArtifactToFile(client, owner, repo, artifact.id, destPath)
+            } catch (error) {
+                if (error.message?.startsWith("Artifact has expired")) {
+                    return setExitMessage(ifNoArtifactFound, "no downloadable artifacts found (expired)")
+                }
+                throw error
+            }
 
+            if (skipUnpack) continue
+
+            // Stream the ZIP to a temp file for extraction.
+            try {
                 const dir = name && (!nameIsRegExp || mergeMultiple) ? path : pathname.join(path, artifact.name)
 
                 fs.mkdirSync(dir, { recursive: true })
@@ -362,10 +321,10 @@ async function main() {
                 core.startGroup(`==> Extracting: ${artifact.name}.zip`)
                 if (useUnzip) {
                     // Temp file is already on disk – hand it straight to unzip.
-                    await exec.exec("unzip", ["-o", tempZipPath, "-d", dir])
+                    await exec.exec("unzip", ["-o", destPath, "-d", dir])
                 } else {
                     // AdmZip file-path constructor: reads entries one at a time, not all into RAM.
-                    const adm = new AdmZip(tempZipPath)
+                    const adm = new AdmZip(destPath)
                     adm.getEntries().forEach((entry) => {
                         const action = entry.isDirectory ? "creating" : "inflating"
                         const filepath = pathname.join(dir, entry.entryName)
@@ -377,7 +336,7 @@ async function main() {
                 core.endGroup()
             } finally {
                 // Always clean up the temp file, even if extraction failed.
-                try { fs.rmSync(tempZipPath) } catch (e) { core.debug(`Failed to remove temp file ${tempZipPath}: ${e.message}`) }
+                try { fs.rmSync(destPath) } catch (e) { core.debug(`Failed to remove temp file ${destPath}: ${e.message}`) }
             }
         }
     } catch (error) {


### PR DESCRIPTION
In `main.js`, every artifact ZIP is currently downloaded by calling Octokit's `downloadArtifact`, which follows the redirect and fetches the **entire** binary response body into a `zip.data` `ArrayBuffer` that lives in Node.js heap memory. That `Buffer.from(zip.data)` is then passed either to `AdmZip` (which also keeps everything in RAM) or written to a temp file for `unzip`. For large artifacts this can easily exhaust the runner's memory and kill the process with an OOM error.

This PR fixes this issue by streaming the downloads to disk.