### PR TITLE
Download artifacts in creation order

### DIFF
--- a/main.js
+++ b/main.js
@@ -229,6 +229,8 @@ async function main() {
             artifacts = filtered
         }
 
+        artifacts.sort((a, b) => a.created_at.localeCompare(b.created_at))
+
         core.setOutput("artifacts", artifacts)
 
         if (dryRun) {


### PR DESCRIPTION
A partial fix for the #384

It ensures artifacts are downloaded in the order they were created. This prevents older artifact from the older run from overriding newer artifacts.

I think this might also be doing the same thing as #241, except that it also handles the multiple re-runs edge case?