### PR TITLE
joint fixes and improvements

### DIFF
--- a/.github/workflows/download.yml
+++ b/.github/workflows/download.yml
@@ -6,6 +6,10 @@ on:
       - master
   pull_request:
 
+permissions:
+  actions: read
+  contents: read
+
 concurrency:
   group: download
 
@@ -189,6 +193,20 @@ jobs:
           ! test -d artifact/artifact
           ! test -f artifact.zip
           unzip -l artifact/artifact.zip
+  download-raw:
+    runs-on: ubuntu-latest
+    needs: wait
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Download
+        uses: ./
+        with:
+          workflow: upload.yml
+          name: raw-artifact
+          path: raw
+      - name: Test
+        run: cat raw/raw-artifact | grep $GITHUB_SHA
   download-use-unzip:
     runs-on: ubuntu-latest
     needs: wait

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -17,11 +17,17 @@ jobs:
         run: |
           mkdir artifact
           echo $GITHUB_SHA > artifact/sha
+          echo $GITHUB_SHA > raw-artifact
       - name: Upload
         uses: actions/upload-artifact@v7
         with:
           name: artifact
           path: artifact
+      - name: Upload raw
+        uses: actions/upload-artifact@v7
+        with:
+          path: raw-artifact
+          archive: false
   upload-multiple:
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 An action that downloads and extracts uploaded artifacts associated with a given workflow and commit or other criteria.
 
-Let's suppose you have a workflow with a job in it that at the end uploads an artifact using `actions/upload-artifact` action and you want to download this artifact in another workflow that is run after the first one. Official `actions/download-artifact` does not allow this. That's why I decided to create this action. By knowing only the workflow name and commit SHA or other details, you can download the previously uploaded artifact from different workflow associated with that commit or other criteria and use it.
+Official [`actions/download-artifact`](https://github.com/actions/download-artifact#download-artifacts-from-other-workflow-runs-or-repositories) can download from another workflow run when its exact run ID is known. This action can also find a run by workflow, commit, branch, tag, pull request or other criteria and download its artifacts.
 
 ## Usage
 
@@ -88,6 +88,10 @@ Let's suppose you have a workflow with a job in it that at the end uploads an ar
     # default false
     merge_multiple: false
 ```
+
+### API usage
+
+Workflow, branch, event, commit/ref and conclusion filters are sent to GitHub's API. `run_number`, fork filtering, `check_artifacts` and `search_artifacts` are evaluated by this action; artifact checks may require an additional paginated API request for every candidate workflow run.
 
 ## Troubleshooting
 

--- a/action.yml
+++ b/action.yml
@@ -43,7 +43,7 @@ inputs:
     description: Branch name
     required: false
   ref:
-    description: Commit hash or branch name
+    description: Commit hash, branch or tag name
     required: false
   event:
     description: Event type

--- a/main.js
+++ b/main.js
@@ -7,28 +7,6 @@ import { filesize } from 'filesize'
 import pathname from 'node:path'
 import fs from 'node:fs'
 
-async function downloadAction(name, path) {
-    const artifactClient = artifact.create()
-    const downloadOptions = {
-        createArtifactFolder: false
-    }
-    const downloadResponse = await artifactClient.downloadArtifact(
-        name,
-        path,
-        downloadOptions
-    )
-    core.setOutput("found_artifact", true)
-}
-
-async function getWorkflow(client, owner, repo, runID) {
-    const run = await client.rest.actions.getWorkflowRun({
-        owner: owner,
-        repo: repo,
-        run_id: runID || github.context.runId,
-    })
-    return run.data.workflow_id
-}
-
 async function main() {
     try {
         const token = core.getInput("github_token", { required: true })
@@ -56,13 +34,20 @@ async function main() {
         let dryRun = core.getInput("dry_run")
 
         const client = github.getOctokit(token)
+        const artifactClient = new artifact.DefaultArtifactClient()
+        const hostname = new URL(github.context.serverUrl).hostname.toUpperCase()
+        const canStreamArtifacts = hostname === "GITHUB.COM" || hostname.endsWith(".GHE.COM") || hostname.endsWith(".LOCALHOST")
 
         core.info(`==> Repository: ${owner}/${repo}`)
         core.info(`==> Artifact name: ${name}`)
         core.info(`==> Local path: ${path}`)
 
         if (!workflow && !workflowSearch) {
-            workflow = await getWorkflow(client, owner, repo, runID)
+            workflow = (await client.rest.actions.getWorkflowRun({
+                owner: owner,
+                repo: repo,
+                run_id: runID || github.context.runId,
+            })).data.workflow_id
         }
 
         if (workflow) {
@@ -102,14 +87,19 @@ async function main() {
             // Try to determine if the ref is a branch or a commit
             core.info(`==> Ref: ${ref}`)
             try {
-                const response = await client.rest.repos.getBranch({
+                await client.rest.repos.getBranch({
                     owner: owner,
                     repo: repo,
                     branch: ref,
                 })
                 branch = ref
             } catch (error) {
-                commit = ref
+                const response = await client.rest.repos.getCommit({
+                    owner: owner,
+                    repo: repo,
+                    ref: ref,
+                })
+                commit = response.data.sha
             }
         }
 
@@ -142,13 +132,11 @@ async function main() {
                 ...(branch ? { branch } : {}),
                 ...(event ? { event } : {}),
                 ...(commit ? { head_sha: commit } : {}),
+                ...(workflowConclusion ? { status: workflowConclusion } : {}),
             }
             )) {
                 for (const run of runs.data) {
                     if (runNumber && run.run_number != runNumber) {
-                        continue
-                    }
-                    if (workflowConclusion && (workflowConclusion != run.conclusion && workflowConclusion != run.status)) {
                         continue
                     }
                     if (!allowForks && run.head_repository.full_name !== `${owner}/${repo}`) {
@@ -182,7 +170,7 @@ async function main() {
                     core.info(`==> (found) Run date: ${run.created_at}`)
 
                     if (!workflow) {
-                        workflow = await getWorkflow(client, owner, repo, runID)
+                        workflow = run.workflow_id
                         core.info(`==> (found) Workflow: ${workflow}`)
                     }
                     break
@@ -197,12 +185,8 @@ async function main() {
             if (workflowConclusion && (workflowConclusion != 'in_progress')) {
                 return setExitMessage(ifNoArtifactFound, "no matching workflow run found with any artifacts?")
             }
-
-            try {
-                return await downloadAction(name, path)
-            } catch (error) {
-                return setExitMessage(ifNoArtifactFound, "no matching artifact in this workflow?")
-            }
+            runID = github.context.runId
+            core.info(`==> (current) Run ID: ${runID}`)
         }
 
         let artifacts = await client.paginate(client.rest.actions.listWorkflowRunArtifacts, {
@@ -265,7 +249,62 @@ async function main() {
 
             const size = filesize(artifact.size_in_bytes, { base: 10 })
 
-            core.info(`==> Downloading: ${artifact.name}.zip (${size})`)
+            core.info(`==> Downloading: ${artifact.name} (${size})`)
+
+            if (artifact.expired) {
+                if (ifNoArtifactFound === "fail") {
+                    return setExitMessage(ifNoArtifactFound, "no downloadable artifacts found (expired)")
+                }
+                expiredArtifacts.push(artifact.name)
+                continue
+            }
+
+            const dir = skipUnpack || (name && (!nameIsRegExp || mergeMultiple))
+                ? path
+                : pathname.join(path, artifact.name)
+
+            if (canStreamArtifacts) {
+                let response
+                try {
+                    response = await artifactClient.downloadArtifact(artifact.id, {
+                        path: dir,
+                        skipDecompress: skipUnpack || useUnzip,
+                        ...(artifact.digest ? { expectedHash: artifact.digest } : {}),
+                        findBy: {
+                            token: token,
+                            workflowRunId: Number(runID),
+                            repositoryOwner: owner,
+                            repositoryName: repo,
+                        },
+                    })
+                } catch (error) {
+                    if (error.message.includes("Artifact has expired")) {
+                        if (ifNoArtifactFound === "fail") {
+                            return setExitMessage(ifNoArtifactFound, "no downloadable artifacts found (expired)")
+                        }
+                        expiredArtifacts.push(artifact.name)
+                        continue
+                    }
+                    throw error
+                }
+
+                if (response.digestMismatch) {
+                    throw new Error(`artifact digest mismatch: ${artifact.name}`)
+                }
+
+                const zipPath = pathname.join(dir, `${artifact.name}.zip`)
+                if (useUnzip && !skipUnpack && fs.existsSync(zipPath)) {
+                    core.startGroup(`==> Extracting: ${artifact.name}.zip`)
+                    try {
+                        await exec.exec("unzip", [zipPath, "-d", dir])
+                    } finally {
+                        core.endGroup()
+                    }
+                    fs.rmSync(zipPath)
+                }
+                downloadedArtifact = true
+                continue
+            }
 
             let zip
             try {
@@ -293,8 +332,6 @@ async function main() {
                 downloadedArtifact = true
                 continue
             }
-
-            const dir = name && (!nameIsRegExp || mergeMultiple) ? path : pathname.join(path, artifact.name)
 
             fs.mkdirSync(dir, { recursive: true })
 


### PR DESCRIPTION
## Summary

- stream artifact downloads instead of buffering complete archives in memory
- support raw artifacts and validate downloaded artifact digests
- resolve branch, commit and tag refs
- filter workflow status through GitHub's API
- clarify the comparison with `actions/download-artifact` and document API usage
- add integration coverage for raw artifacts

GitHub Enterprise Server keeps the existing buffered ZIP download path because `@actions/artifact` does not support GHES.

## Checks

- GitHub Actions integration workflow
- CodeQL
- `node --check main.js`
- `git diff --check`

Fixes #403
Fixes #201
Fixes #230
Fixes #245
Fixes #223
Fixes #298
Fixes #164