### PR TITLE
fix: stream GHES artifact downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ Official [`actions/download-artifact`](https://github.com/actions/download-artif
     merge_multiple: false
 ```
 
+On GitHub Enterprise Server, use `use_unzip: true` for large artifacts so extraction does not load the complete ZIP into memory.
+
 ### API usage
 
 Workflow, branch, event, commit/ref and conclusion filters are sent to GitHub's API. `run_number`, fork filtering, `check_artifacts` and `search_artifacts` are evaluated by this action; artifact checks may require an additional paginated API request for every candidate workflow run.

--- a/main.js
+++ b/main.js
@@ -1,11 +1,14 @@
 import * as core from '@actions/core'
 import * as exec from '@actions/exec'
 import * as github from '@actions/github'
+import { defaults as githubDefaults } from '@actions/github/lib/utils'
 import * as artifact from '@actions/artifact'
 import AdmZip from 'adm-zip'
 import { filesize } from 'filesize'
+import { randomUUID } from 'node:crypto'
 import pathname from 'node:path'
 import fs from 'node:fs'
+import { pipeline } from 'node:stream/promises'
 
 async function main() {
     try {
@@ -306,53 +309,67 @@ async function main() {
                 continue
             }
 
-            let zip
+            fs.mkdirSync(dir, { recursive: true })
+            const zipPath = pathname.join(dir, `.artifact-${randomUUID()}.zip`)
+
             try {
-                zip = await client.rest.actions.downloadArtifact({
+                await client.request("GET /repos/{owner}/{repo}/actions/artifacts/{artifact_id}/{archive_format}", {
                     owner: owner,
                     repo: repo,
                     artifact_id: artifact.id,
                     archive_format: "zip",
+                    request: {
+                        fetch: async (url, options) => {
+                            const response = await githubDefaults.request.fetch(url, { ...options, redirect: "follow" })
+                            if (!response.ok) return response
+                            await pipeline(response.body, fs.createWriteStream(zipPath))
+                            return new Response(null, { status: 200, headers: response.headers })
+                        },
+                    },
                 })
             } catch (error) {
-                if (error.message.startsWith("Artifact has expired")) {
+                fs.rmSync(zipPath, { force: true })
+                if (error.message?.startsWith("Artifact has expired")) {
                     if (ifNoArtifactFound === "fail") {
                         return setExitMessage(ifNoArtifactFound, "no downloadable artifacts found (expired)")
                     }
                     expiredArtifacts.push(artifact.name)
                     continue
-                } else {
-                    throw new Error(error.message)
                 }
+                throw error
             }
 
+            downloadedArtifact = true
             if (skipUnpack) {
-                fs.mkdirSync(path, { recursive: true })
-                fs.writeFileSync(`${pathname.join(path, artifact.name)}.zip`, Buffer.from(zip.data), 'binary')
-                downloadedArtifact = true
+                try {
+                    fs.renameSync(zipPath, `${pathname.join(path, artifact.name)}.zip`)
+                } finally {
+                    fs.rmSync(zipPath, { force: true })
+                }
                 continue
             }
 
-            fs.mkdirSync(dir, { recursive: true })
+            try {
+                core.startGroup(`==> Extracting: ${artifact.name}.zip`)
+                try {
+                    if (useUnzip) {
+                        await exec.exec("unzip", [zipPath, "-d", dir])
+                    } else {
+                        const adm = new AdmZip(zipPath)
+                        adm.getEntries().forEach((entry) => {
+                            const action = entry.isDirectory ? "creating" : "inflating"
+                            const filepath = pathname.join(dir, entry.entryName)
 
-            core.startGroup(`==> Extracting: ${artifact.name}.zip`)
-            if (useUnzip) {
-                const zipPath = `${pathname.join(dir, artifact.name)}.zip`
-                fs.writeFileSync(zipPath, Buffer.from(zip.data), 'binary')
-                await exec.exec("unzip", [zipPath, "-d", dir])
-                fs.rmSync(zipPath)
-            } else {
-                const adm = new AdmZip(Buffer.from(zip.data))
-                adm.getEntries().forEach((entry) => {
-                    const action = entry.isDirectory ? "creating" : "inflating"
-                    const filepath = pathname.join(dir, entry.entryName)
-
-                    core.info(`  ${action}: ${filepath}`)
-                })
-                adm.extractAllTo(dir, true)
+                            core.info(`  ${action}: ${filepath}`)
+                        })
+                        adm.extractAllTo(dir, true)
+                    }
+                } finally {
+                    core.endGroup()
+                }
+            } finally {
+                fs.rmSync(zipPath, { force: true })
             }
-            core.endGroup()
-            downloadedArtifact = true
         }
 
         if (!downloadedArtifact) {


### PR DESCRIPTION
## Summary

- stream GitHub Enterprise Server artifact downloads to disk instead of buffering complete responses in memory
- preserve `skip_unpack` behavior and always clean up partial and temporary files
- document `use_unzip: true` for fully streamed extraction on GHES

GitHub.com continues to use `@actions/artifact` for streamed extraction, raw-artifact support and digest validation. On GHES, downloads now stream in every mode; extraction remains memory-buffered through `AdmZip` unless `use_unzip: true` is selected.

Adapted from #397 by @yeicor.

## Checks

- `node --check main.js`
- `git diff --check`