### PR TITLE
chore: remove redundant action code

### DIFF
--- a/.github/workflows/download.yml
+++ b/.github/workflows/download.yml
@@ -242,7 +242,7 @@ jobs:
           path: artifact
           dry_run: true
       - name: Test
-        run: test ${{ steps.download.outputs.dry_run }} == true
+        run: test ${{ steps.download.outputs.found_artifact }} == true
   download-dry-run-not-exists:
     runs-on: ubuntu-latest
     needs: wait
@@ -258,7 +258,7 @@ jobs:
           path: artifact
           dry_run: true
       - name: Test
-        run: test ${{ steps.download.outputs.dry_run }} == false
+        run: test ${{ steps.download.outputs.found_artifact }} == false
   download-with-check-artifacts:
     runs-on: ubuntu-latest
     needs: wait

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -18,10 +18,7 @@ jobs:
       - name: Dump
         run: |
           mkdir artifact artifact1 artifact2
-          echo $GITHUB_SHA > raw-artifact
-          echo $GITHUB_SHA > artifact/sha
-          echo $GITHUB_SHA > artifact1/sha1
-          echo $GITHUB_SHA > artifact2/sha2
+          printf '%s\n' "$GITHUB_SHA" | tee raw-artifact artifact/sha artifact1/sha1 artifact2/sha2 > /dev/null
       - name: Upload
         uses: actions/upload-artifact@v7
         with:

--- a/action.yml
+++ b/action.yml
@@ -79,9 +79,6 @@ inputs:
 outputs:
   error_message:
     description: The error message, if an error occurs
-  # TODO: dry_run should be merged with found_artifact output
-  dry_run:
-    description: Boolean output which is true if the dry run was successful and false otherwise
   found_artifact:
     description: Boolean output which is true if the artifact was found and false otherwise
   artifacts:

--- a/main.js
+++ b/main.js
@@ -199,29 +199,23 @@ async function main() {
         core.setOutput("artifacts", artifacts)
 
         if (dryRun) {
-            if (artifacts.length == 0) {
-                core.setOutput("dry_run", false)
-                core.setOutput("found_artifact", false)
-                return
-            } else {
-                core.setOutput("dry_run", true)
-                core.setOutput("found_artifact", true)
-                core.info('==> (found) Artifacts')
-                for (const artifact of artifacts) {
-                    core.info(`\t==> Artifact:`)
-                    core.info(`\t==> ID: ${artifact.id}`)
-                    core.info(`\t==> Name: ${artifact.name}`)
-                    core.info(`\t==> Size: ${artifact.size_in_bytes} bytes`)
-                }
-                return
+            const found = artifacts.length > 0
+            core.setOutput("found_artifact", found)
+            if (!found) return
+            core.info('==> (found) Artifacts')
+            for (const artifact of artifacts) {
+                core.info(`\t==> Artifact:`)
+                core.info(`\t==> ID: ${artifact.id}`)
+                core.info(`\t==> Name: ${artifact.name}`)
+                core.info(`\t==> Size: ${artifact.size_in_bytes} bytes`)
             }
+            return
         }
 
         if (artifacts.length == 0) {
             return setExitMessage(ifNoArtifactFound, "no artifacts found")
         }
 
-        let downloadedArtifact = false
         const expiredArtifacts = []
 
         for (const artifact of artifacts) {
@@ -280,7 +274,6 @@ async function main() {
                     }
                     fs.rmSync(zipPath)
                 }
-                downloadedArtifact = true
                 continue
             }
 
@@ -314,7 +307,6 @@ async function main() {
                 throw error
             }
 
-            downloadedArtifact = true
             if (skipUnpack) {
                 try {
                     fs.renameSync(zipPath, `${pathname.join(path, artifact.name)}.zip`)
@@ -330,14 +322,7 @@ async function main() {
                     if (useUnzip) {
                         await exec.exec("unzip", [zipPath, "-d", dir])
                     } else {
-                        const adm = new AdmZip(zipPath)
-                        adm.getEntries().forEach((entry) => {
-                            const action = entry.isDirectory ? "creating" : "inflating"
-                            const filepath = pathname.join(dir, entry.entryName)
-
-                            core.info(`  ${action}: ${filepath}`)
-                        })
-                        adm.extractAllTo(dir, true)
+                        new AdmZip(zipPath).extractAllTo(dir, true)
                     }
                 } finally {
                     core.endGroup()
@@ -347,7 +332,7 @@ async function main() {
             }
         }
 
-        if (!downloadedArtifact) {
+        if (expiredArtifacts.length === artifacts.length) {
             return setExitMessage(ifNoArtifactFound, "no downloadable artifacts found (expired)")
         }
 
@@ -370,19 +355,9 @@ async function main() {
 
     function setExitMessage(ifNoArtifactFound, message) {
         core.setOutput("found_artifact", false)
-
-        switch (ifNoArtifactFound) {
-            case "fail":
-                core.setFailed(message)
-                break
-            case "warn":
-                core.warning(message)
-                break
-            case "ignore":
-            default:
-                core.info(message)
-                break
-        }
+        if (ifNoArtifactFound === "fail") return core.setFailed(message)
+        if (ifNoArtifactFound === "warn") return core.warning(message)
+        core.info(message)
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "action-download-artifact",
   "type": "module",
-  "main": "main.js",
   "dependencies": {
     "@actions/artifact": "^6.2.1",
     "@actions/core": "^3.0.1",


### PR DESCRIPTION
## Summary

- use one boolean for dry-run artifact detection
- remove redundant download state and per-entry ZIP logging
- simplify exit handling and integration fixture creation
- remove unused package metadata

## Compatibility

The dry_run input remains unchanged. The duplicate dry_run output is removed; consumers should use found_artifact instead.

## Validation

- node --check main.js
- npm ls --all
- parsed action and workflow YAML files
- verified the fixture tee command
- git diff --check